### PR TITLE
python-minio API integration, endpoint to display all objects at /upl…

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -15,6 +15,9 @@ services:
     environment:
       FLASK_ENV: production
       ST_DATABASE_URI: "mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql/${MYSQL_DATABASE}"
+      MINIO_ENDPOINT: minio:9000
+      MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY}"
+      MINIO_SECRET_KEY: "${MINIO_SECRET_KEY}"
     ports:
       - "5000:5000"
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,9 @@ services:
     environment:
       FLASK_ENV: development
       ST_DATABASE_URI: "mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql/${MYSQL_DATABASE}"
+      MINIO_ENDPOINT: minio:9000
+      MINIO_ACCESS_KEY: "${MINIO_ACCESS_KEY}"
+      MINIO_SECRET_KEY: "${MINIO_SECRET_KEY}"
     ports:
       - "5000:5000"
     depends_on:

--- a/flask/app/__init__.py
+++ b/flask/app/__init__.py
@@ -15,3 +15,4 @@ migrate = Migrate(app, db)
 
 from app.manage import *
 from app.routes import *
+from app.buckets import *

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -3,12 +3,9 @@ from flask import request, json, jsonify
 from minio import Minio
 from minio.error import ResponseError
 
-access_key = app.config.get('MINIO_ACCESS_KEY')
-secret_key = app.config.get('MINIO_SECRET_KEY')
-
-minioClient = Minio('minio:9000', 
-                    access_key = access_key, 
-                    secret_key = secret_key,
+minioClient = Minio(app.config.get('MINIO_ENDPOINT'),
+                    access_key = app.config.get('MINIO_ACCESS_KEY'),
+                    secret_key = app.config.get('MINIO_SECRET_KEY'),
                      secure = False)
 
 
@@ -24,12 +21,11 @@ def get_object_info():
         for obj in bucket_objects:
             object_dict = obj.__dict__
             all_objects.append({'bucket_name': object_dict['bucket_name'],
-                                'object_name': object_dict['object_name'], 
+                                'object_name': object_dict['object_name'],
                                 'owner_name': object_dict['owner_name'],
-                                'size': round(object_dict['size'] * 1e-6, 3),  
+                                'size': round(object_dict['size'] * 1e-6, 3),
                                 'etag': object_dict['etag'],
                                 'last_modified': (object_dict['last_modified'])})
 
     return jsonify(all_objects)
 
-  

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -1,0 +1,35 @@
+from app import app
+from flask import request, json, jsonify
+from minio import Minio
+from minio.error import ResponseError
+
+access_key = app.config.get('MINIO_ACCESS_KEY')
+secret_key = app.config.get('MINIO_SECRET_KEY')
+
+minioClient = Minio('minio:9000', 
+                    access_key = access_key, 
+                    secret_key = secret_key,
+                     secure = False)
+
+
+# display all objects, in buckets
+@app.route('/api/objects', methods = ["GET"])
+def get_object_info():
+    all_objects = []
+
+    bucket_names = [bucket.name for bucket in minioClient.list_buckets()]
+
+    for bucket_name in bucket_names:
+        bucket_objects = minioClient.list_objects(bucket_name)
+        for obj in bucket_objects:
+            object_dict = obj.__dict__
+            all_objects.append({'bucket_name': object_dict['bucket_name'],
+                                'object_name': object_dict['object_name'], 
+                                'owner_name': object_dict['owner_name'],
+                                'size': round(object_dict['size'] * 1e-6, 3),  
+                                'etag': object_dict['etag'],
+                                'last_modified': (object_dict['last_modified'])})
+
+    return jsonify(all_objects)
+
+  

--- a/flask/app/config.py
+++ b/flask/app/config.py
@@ -10,6 +10,7 @@ class Config(object):
     DEFAULT_ADMIN = os.getenv('ST_DEFAULT_ADMIN', 'admin')
     DEFAULT_ADMIN_EMAIL = os.getenv('ST_DEFAULT_EMAIL', 'admin@sampletracker.ccm.sickkids.ca')
     DEFAULT_PASSWORD = os.getenv('ST_DEFAULT_PASSWORD', 'eternity')
+    MINIO_ENDPOINT = os.getenv('MINIO_ENDPOINT', 'localhost:9000')
     MINIO_SECRET_KEY = os.getenv('MINIO_SECRET_KEY', 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY' )
     MINIO_ACCESS_KEY = os.getenv('MINIO_ACCESS_KEY', 'AKIAIOSFODNN7EXAMPLE')
 

--- a/flask/app/config.py
+++ b/flask/app/config.py
@@ -10,3 +10,6 @@ class Config(object):
     DEFAULT_ADMIN = os.getenv('ST_DEFAULT_ADMIN', 'admin')
     DEFAULT_ADMIN_EMAIL = os.getenv('ST_DEFAULT_EMAIL', 'admin@sampletracker.ccm.sickkids.ca')
     DEFAULT_PASSWORD = os.getenv('ST_DEFAULT_PASSWORD', 'eternity')
+    MINIO_SECRET_KEY = os.getenv('MINIO_SECRET_KEY', 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY' )
+    MINIO_ACCESS_KEY = os.getenv('MINIO_ACCESS_KEY', 'AKIAIOSFODNN7EXAMPLE')
+

--- a/flask/requirements.in
+++ b/flask/requirements.in
@@ -7,3 +7,4 @@ gunicorn
 pymysql[rsa]
 sqlalchemy
 werkzeug
+minio

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -5,26 +5,31 @@
 #    pip-compile requirements.in
 #
 alembic==1.4.2            # via flask-migrate
+certifi==2020.6.20        # via minio
 cffi==1.14.0              # via cryptography
 click==7.1.1              # via flask
+configparser==5.0.0       # via minio
 cryptography==2.9         # via pymysql
-flask-login==0.5.0
-flask-migrate==2.5.3
-flask-sqlalchemy==2.4.1
-flask-wtf==0.14.3
-flask==1.1.2
-gunicorn==20.0.4
+flask-login==0.5.0        # via -r requirements.in
+flask-migrate==2.5.3      # via -r requirements.in
+flask-sqlalchemy==2.4.1   # via -r requirements.in, flask-migrate
+flask-wtf==0.14.3         # via -r requirements.in
+flask==1.1.2              # via -r requirements.in, flask-login, flask-migrate, flask-sqlalchemy, flask-wtf
+gunicorn==20.0.4          # via -r requirements.in
 itsdangerous==1.1.0       # via flask, flask-wtf
 jinja2==2.11.1            # via flask
 mako==1.1.2               # via alembic
 markupsafe==1.1.1         # via jinja2, mako
+minio==6.0.0              # via -r requirements.in
 pycparser==2.20           # via cffi
-pymysql[rsa]==0.9.3
-python-dateutil==2.8.1    # via alembic
+pymysql[rsa]==0.9.3       # via -r requirements.in
+python-dateutil==2.8.1    # via alembic, minio
 python-editor==1.0.4      # via alembic
+pytz==2020.1              # via minio
 six==1.14.0               # via cryptography, python-dateutil
-sqlalchemy==1.3.15
-werkzeug==1.0.1
+sqlalchemy==1.3.15        # via -r requirements.in, alembic, flask-sqlalchemy
+urllib3==1.25.10          # via minio
+werkzeug==1.0.1           # via -r requirements.in, flask
 wtforms==2.2.1            # via flask-wtf
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/react/src/pages/upload/FilesTable.tsx
+++ b/react/src/pages/upload/FilesTable.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { makeStyles } from '@material-ui/core/styles';
 import Chip from '@material-ui/core/Chip';
 import MaterialTable, { MTableToolbar } from 'material-table';
+import { useState, useEffect } from 'react';
 
 const useStyles = makeStyles(theme => ({
     chip: {
@@ -11,32 +12,49 @@ const useStyles = makeStyles(theme => ({
     }
 }));
 
-function createFile(name: string, uploader: string, size: number, md5: string, created: string) {
-    return { name, uploader, size, md5, created };
+
+function createFile(object_name: string, owner_id: string, size: number, etag: string, last_modified : string) {
+    return { object_name, owner_id, size, etag, last_modified };
 }
 
-const rows = [
-    createFile('1900_4312A_R1.fastq.gz', 'CHEO', 102400, '3a72eed94ddd4fafff9e4c2ba88cae02', '2020-02-01'),
-    createFile('1900_4312A_R2.fastq.gz', 'CHEO', 102400, '7894a2a8b3944340f5e1c1120eeeb621', '2020-02-01'),
-    createFile('1200_12443.bam', 'ACH', 102400, 'ba27a3fc4777369dc8a183fa42d5169e', '2020-02-01'),
-    createFile('930_02000.sam', 'ACH', 102400, 'd6d43f22fa0417850cb94b7cbfd1a25c', '2020-02-01'),
-    createFile('1024_2048B.cram', 'SK', 132233134, '2edcbb4ea21b500e2eb1ae81f310d0c1', '2020-02-01'),
-    createFile('2048_2048B.cram', 'BTS', 132233134, '6a413de1dc394de5384d300041922848', '2020-02-01'),
-];
 
 export default function FilesTable() {
     const classes = useStyles();
 
+    const [data, setData] = useState([createFile(
+        'TESTER.fastq.gz', 'CHEO', 6611, '3a72eed94ddd4fafff9e4c2ba88cae02', '2020-09-01'
+        )]);
+
+    //for error handling (?)
+    const [iserror, setIserror] = useState(false)
+    const [errorMessages, setErrorMessages] = useState([''])
+
+
+    useEffect(() => {
+        fetch("/api/objects").then(res => res.json()).then(res => {
+            setData(res);
+          })
+
+          // not entirely sure how this works 
+          .catch(error=>{
+            setErrorMessages(["Error..."])
+            setIserror(true)
+          })
+      }, [])
+    
+
     return (
         <MaterialTable
+            // fields need to be identical to json keys
             columns={[
-                { title: 'File name', field: 'name' },
-                { title: 'Uploader', field: 'uploader' },
+                { title: 'File name', field: 'object_name' },
+                { title: 'Uploader', field: 'owner_name' },
+                { title: 'Bucket Name', field: 'bucket_name' },
                 { title: 'Size (mb)', field: 'size', type: 'numeric' },
-                { title: 'MD5sum', field: 'md5', type: 'string' },
-                { title: 'Created', field: 'created', type: 'string' }
+                { title: 'etag', field: 'etag', type: 'string' },
+                { title: 'Last Modified', field: 'last_modified', type: 'string' }
             ]}
-            data={rows}
+            data={data}
             title="Unlinked files"
             options={{
                 pageSize: 5,

--- a/react/src/pages/upload/FilesTable.tsx
+++ b/react/src/pages/upload/FilesTable.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import React, { useState, useEffect }  from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Chip from '@material-ui/core/Chip';
 import MaterialTable, { MTableToolbar } from 'material-table';
-import { useState, useEffect } from 'react';
+
 
 const useStyles = makeStyles(theme => ({
     chip: {
@@ -21,23 +21,15 @@ function createFile(object_name: string, owner_id: string, size: number, etag: s
 export default function FilesTable() {
     const classes = useStyles();
 
-    const [data, setData] = useState([createFile(
-        'TESTER.fastq.gz', 'CHEO', 6611, '3a72eed94ddd4fafff9e4c2ba88cae02', '2020-09-01'
-        )]);
-
-    //for error handling (?)
+    const [data, setData] = useState([]);
     const [iserror, setIserror] = useState(false)
-    const [errorMessages, setErrorMessages] = useState([''])
 
 
     useEffect(() => {
         fetch("/api/objects").then(res => res.json()).then(res => {
             setData(res);
           })
-
-          // not entirely sure how this works 
           .catch(error=>{
-            setErrorMessages(["Error..."])
             setIserror(true)
           })
       }, [])


### PR DESCRIPTION
…oads

- the minio endpoints are in `buckets.py`, can merge into `routes.py` if needed
- wasn't sure how to provide the minio access and secret keys so I just placed it in `config.py` 
-  to rebuild the flask app in docker b/c of new dependencies (I am not sure if this needs to be done?): `docker-compose -f docker-compose.yaml build app`