### PR TITLE
Per-column table filtering 

### DIFF
--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -150,6 +150,8 @@ export default function Analysis() {
                     }
                     options={{
                         pageSize: 10,
+                        filtering: true,
+                        search: false
                     }}
                     actions={[
                         {

--- a/react/src/pages/analysis/DatasetTable.tsx
+++ b/react/src/pages/analysis/DatasetTable.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableContainer from '@material-ui/core/TableContainer';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import Paper from '@material-ui/core/Paper';
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@material-ui/core';
+
 
 const useStyles = makeStyles({
     table: {

--- a/react/src/pages/dashboard/AnalysisTable.tsx
+++ b/react/src/pages/dashboard/AnalysisTable.tsx
@@ -1,13 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import Grid from '@material-ui/core/Grid';
-import Link from '@material-ui/core/Link';
-import Paper from '@material-ui/core/Paper';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
+import { makeStyles, Grid, Link, Paper, Table, TableBody, TableCell, TableHead, TableRow } from '@material-ui/core';
 import { PipelineStatus } from '../analysis/Analysis';
 
 import Title from '../Title';

--- a/react/src/pages/dashboard/SamplesTable.tsx
+++ b/react/src/pages/dashboard/SamplesTable.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Chip from '@material-ui/core/Chip';
 import MaterialTable, { MTableToolbar } from 'material-table';
+import { Cancel } from '@material-ui/icons';
+import { IconButton } from '@material-ui/core';
 
 
 export interface Sample {
@@ -86,7 +88,7 @@ export default function SamplesTable() {
                                 <Chip label="SK" clickable className={classes.chip} onClick={() => setCentre("SK")}/>
                                 <Chip label="ACH" clickable className={classes.chip} onClick={() => setCentre("ACH")}/>
                                 <Chip label="BCL" clickable className={classes.chip} onClick={() => setCentre("BCL")}/>
-                                <Chip label="x" clickable className={classes.chip} onClick={() => setCentre("")}/>
+                                <IconButton className={classes.chip} onClick={() => setCentre("")}> <Cancel/> </IconButton>
                             </div>
                         </div>
                     ),

--- a/react/src/pages/dashboard/SamplesTable.tsx
+++ b/react/src/pages/dashboard/SamplesTable.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import Chip from '@material-ui/core/Chip';
+import { Chip, IconButton } from '@material-ui/core';
 import MaterialTable, { MTableToolbar } from 'material-table';
 import { Cancel } from '@material-ui/icons';
-import { IconButton } from '@material-ui/core';
 
 
 export interface Sample {
@@ -64,7 +63,7 @@ export default function SamplesTable() {
                 columns={[
                     { title: 'Project', field: 'project' },
                     { title: 'Participant', field: 'participantID' },
-                    { title: 'Uploader', field: 'uploader' , defaultFilter: centre},
+                    { title: 'Uploader', field: 'uploader' , defaultFilter: centre },
                     { title: 'Tissue', field: 'tissueType'},
                     { title: 'Data Type', field: 'dataType'},
                     { title: 'Relation', field: 'relation'},

--- a/react/src/pages/dashboard/SamplesTable.tsx
+++ b/react/src/pages/dashboard/SamplesTable.tsx
@@ -74,7 +74,8 @@ export default function SamplesTable() {
                 options={{
                     pageSize: 10,
                     selection: false,
-
+                    filtering: true,
+                    search: false
                 }}
                 components={{
                     Toolbar: props => (

--- a/react/src/pages/participants/ParticipantsTable.tsx
+++ b/react/src/pages/participants/ParticipantsTable.tsx
@@ -1,12 +1,9 @@
 import React, { useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import Chip from '@material-ui/core/Chip';
+import { Chip, IconButton } from '@material-ui/core';
 import MaterialTable, { MTableToolbar } from 'material-table';
-import PlayArrowIcon from '@material-ui/icons/PlayArrow';
-import DeleteIcon from '@material-ui/icons/Delete';
+import { PlayArrow, Delete, Cancel } from '@material-ui/icons';
 import AnalysisRunnerDialog from './AnalysisRunnerDialog';
-import { Cancel } from '@material-ui/icons';
-import { IconButton } from '@material-ui/core';
 
 export interface Participant {
     participantID: string,
@@ -73,7 +70,7 @@ export default function ParticipantsTable({ display }: ParticipantsTableProps) {
                 columns={[
                     { title: 'Participant', field: 'participantID' },
                     { title: 'Project', field: 'project' },
-                    { title: 'Uploader', field: 'uploader', defaultFilter: centre},
+                    { title: 'Uploader', field: 'uploader', defaultFilter: centre },
                     { title: 'Num. Samples', field: 'numSamples', type: 'numeric' },
                     { title: 'Sex', field: 'sex', type: 'string' },
                     { title: 'Created', field: 'created', type: 'string' }
@@ -116,7 +113,7 @@ export default function ParticipantsTable({ display }: ParticipantsTableProps) {
                 actions={[
                     {
                         tooltip: 'Delete the selected participants',
-                        icon: DeleteIcon,
+                        icon: Delete,
                         onClick: (evt, data) => {
                             const sampleString = (data as Participant[]).map((participant) => { return participant.participantID }).join(', ')
                             alert(`Withdraw all datasets and records associated with the samples: ${sampleString}`)
@@ -124,7 +121,7 @@ export default function ParticipantsTable({ display }: ParticipantsTableProps) {
                     },
                     {
                         tooltip: 'Run an analysis with the selected datasets',
-                        icon: PlayArrowIcon,
+                        icon: PlayArrow,
                         onClick: (evt, data) => {
                             setActiveParticipants(data as Participant[])
                             setRunner(true)

--- a/react/src/pages/participants/ParticipantsTable.tsx
+++ b/react/src/pages/participants/ParticipantsTable.tsx
@@ -5,6 +5,8 @@ import MaterialTable, { MTableToolbar } from 'material-table';
 import PlayArrowIcon from '@material-ui/icons/PlayArrow';
 import DeleteIcon from '@material-ui/icons/Delete';
 import AnalysisRunnerDialog from './AnalysisRunnerDialog';
+import { Cancel } from '@material-ui/icons';
+import { IconButton } from '@material-ui/core';
 
 export interface Participant {
     participantID: string,
@@ -58,6 +60,7 @@ export default function ParticipantsTable({ display }: ParticipantsTableProps) {
     const classes = useStyles();
     const [showRunner, setRunner] = useState(false);
     const [activeParticipants, setActiveParticipants] = useState<Participant[]>([]);
+    const [centre, setCentre] = useState("");
 
     return (
         <div>
@@ -70,7 +73,7 @@ export default function ParticipantsTable({ display }: ParticipantsTableProps) {
                 columns={[
                     { title: 'Participant', field: 'participantID' },
                     { title: 'Project', field: 'project' },
-                    { title: 'Uploader', field: 'uploader' },
+                    { title: 'Uploader', field: 'uploader', defaultFilter: centre},
                     { title: 'Num. Samples', field: 'numSamples', type: 'numeric' },
                     { title: 'Sex', field: 'sex', type: 'string' },
                     { title: 'Created', field: 'created', type: 'string' }
@@ -101,11 +104,11 @@ export default function ParticipantsTable({ display }: ParticipantsTableProps) {
                         <div>
                             <MTableToolbar {...props} />
                             <div style={{ marginLeft: '24px' }}>
-                                <Chip label="CHEO" clickable className={classes.chip} />
-                                <Chip label="SK" clickable className={classes.chip} />
-                                <Chip label="ACH" clickable className={classes.chip} />
-                                <Chip label="BCL" clickable className={classes.chip} />
-                                <Chip label="Misc." clickable className={classes.chip} />
+                                <Chip label="CHEO" clickable className={classes.chip} onClick={() => setCentre("CHEO")} />
+                                <Chip label="SK" clickable className={classes.chip} onClick={() => setCentre("SK")} />
+                                <Chip label="ACH" clickable className={classes.chip} onClick={() => setCentre("ACH")} />
+                                <Chip label="BCL" clickable className={classes.chip} onClick={() => setCentre("BCL")} />
+                                <IconButton className={classes.chip} onClick={() => setCentre("")}> <Cancel/> </IconButton>
                             </div>
                         </div>
                     ),
@@ -116,7 +119,7 @@ export default function ParticipantsTable({ display }: ParticipantsTableProps) {
                         icon: DeleteIcon,
                         onClick: (evt, data) => {
                             const sampleString = (data as Participant[]).map((participant) => { return participant.participantID }).join(', ')
-                            alert(`Widthdraw all datasets and records associated with the samples: ${sampleString}`)
+                            alert(`Withdraw all datasets and records associated with the samples: ${sampleString}`)
                         }
                     },
                     {

--- a/react/src/pages/participants/ParticipantsTable.tsx
+++ b/react/src/pages/participants/ParticipantsTable.tsx
@@ -79,7 +79,9 @@ export default function ParticipantsTable({ display }: ParticipantsTableProps) {
                 title={display}
                 options={{
                     pageSize: 10,
-                    selection: true
+                    selection: true,
+                    filtering: true,
+                    search: false
                 }}
                 editable={{
                     onRowUpdate: (newData, oldData) =>

--- a/react/src/pages/upload/FilesTable.tsx
+++ b/react/src/pages/upload/FilesTable.tsx
@@ -50,7 +50,9 @@ export default function FilesTable() {
             title="Unlinked files"
             options={{
                 pageSize: 5,
-                selection: true
+                selection: true,
+                filtering: true,
+                search: false
             }}
             components={{
                 Toolbar: props => (


### PR DESCRIPTION
The material-table component provides built-in per-column filtering options. This change nullifies the need for a general search bar, so it is also disabled.