### PR TITLE
Flask: add PATCH /api/participants/<id>

### DIFF
--- a/flask/app/models.py
+++ b/flask/app/models.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+from typing import List
 
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
@@ -25,20 +26,22 @@ class User(UserMixin, db.Model):
         return self.user_id
 
 
+@dataclass
 class Group(db.Model):
-    group_id = db.Column(db.Integer, primary_key=True)
-    group_code = db.Column(db.String(50), nullable=False, unique=True) # i.e. CHEO, SK, AB
-    group_name = db.Column(db.String(250), nullable=False, unique=True) # full group name
+    group_id: int = db.Column(db.Integer, primary_key=True)
+    group_code: str = db.Column(db.String(50), nullable=False, unique=True) # i.e. CHEO, SK, AB
+    group_name: str = db.Column(db.String(250), nullable=False, unique=True) # full group name
 
 
+@dataclass
 class Family(db.Model):
-    family_id = db.Column(db.Integer, primary_key=True)
+    family_id: int = db.Column(db.Integer, primary_key=True)
     # Family.FamilyID
-    family_codename = db.Column(db.String(50), nullable=False, unique=True)
-    created = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
-    created_by = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
-    updated = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
-    updated_by = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
+    family_codename: str = db.Column(db.String(50), nullable=False, unique=True)
+    created: str = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    created_by: int = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
+    updated: str = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+    updated_by: int = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
     participants = db.relationship('Participant', backref='family', lazy='dynamic')
 
 
@@ -71,13 +74,13 @@ class Participant(db.Model):
     solved: bool = db.Column(db.Boolean) #TODO uncomment and rebuild
     notes: str = db.Column(db.Text)
     created: datetime = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
-    created_by = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
+    created_by: int = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
     updated: datetime = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
-    updated_by = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
+    updated_by: int = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
     tissue_samples = db.relationship('TissueSample', backref='participant', lazy='dynamic')
 
 
-class TissueSampleType(Enum):
+class TissueSampleType(str, Enum):
     Blood = 'Blood'  # BLO
     Saliva = 'Saliva'  # SAL
     Lymphocyte = 'Lymphocyte'  # LYM
@@ -90,28 +93,29 @@ class TissueSampleType(Enum):
     Kidney = 'Kidney'  # KID
 
 
-class TissueProcessing(Enum):
+class TissueProcessing(str, Enum):
     FreshFrozen = 'FF'
     Formaldehyde = 'FFPE'
 
 
+@dataclass
 class TissueSample(db.Model):
-    tissue_sample_id = db.Column(db.Integer, primary_key=True)
-    participant_id = db.Column(db.Integer, db.ForeignKey('participant.participant_id'), nullable=False)
-    extraction_date = db.Column(db.Date)
+    tissue_sample_id: int = db.Column(db.Integer, primary_key=True)
+    participant_id: int = db.Column(db.Integer, db.ForeignKey('participant.participant_id'), nullable=False)
+    extraction_date: datetime = db.Column(db.Date)
     # Sample.TissueType
-    tissue_sample_type = db.Column(db.Enum(TissueSampleType), nullable=False)
+    tissue_sample_type: TissueSampleType = db.Column(db.Enum(TissueSampleType), nullable=False)
     # RNASeqDataset.TissueProcessing
-    tissue_processing = db.Column(db.Enum(TissueProcessing))
-    notes = db.Column(db.Text)
-    created = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
-    created_by = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
-    updated = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.now)
-    updated_by = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
+    tissue_processing: TissueProcessing = db.Column(db.Enum(TissueProcessing))
+    notes: str = db.Column(db.Text)
+    created: datetime = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    created_by: int = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
+    updated: datetime = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.now)
+    updated_by: int = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
     datasets = db.relationship('Dataset', backref='tissue_sample', lazy='dynamic')
 
 
-class DatasetType(Enum):
+class DatasetType(str, Enum):
     CES = 'CES'
     CGS = 'CGS'
     CPS = 'CPS'
@@ -130,17 +134,17 @@ class DatasetType(Enum):
 
 
 # Name TBD
-class DatasetCondition(Enum):
+class DatasetCondition(str, Enum):
     Control = 'Control'
     GermLine = 'GermLine'  # e.g. rare diseases
     Somatic = 'Somatic'  # e.g. cancer
 
 
-class DatasetExtractionProtocol(Enum):
-    Something = 1
+class DatasetExtractionProtocol(str, Enum):
+    Something = 'Something'
 
 
-class DatasetReadType(Enum):
+class DatasetReadType(str, Enum):
     PairedEnd = 'PairedEnd'
     SingleEnd = 'SingleEnd'
 
@@ -166,38 +170,39 @@ datasets_analyses_table = db.Table(
 )
 
 
+@dataclass
 class Dataset(db.Model):
     __tablename__ = 'dataset'
-    tissue_sample_id = db.Column(db.Integer, db.ForeignKey('tissue_sample.tissue_sample_id'), nullable=False)
+    tissue_sample_id: int = db.Column(db.Integer, db.ForeignKey('tissue_sample.tissue_sample_id'), nullable=False)
     # Dataset.DatasetID
-    dataset_id = db.Column(db.Integer, primary_key=True)
+    dataset_id: int = db.Column(db.Integer, primary_key=True)
     # Dataset.DatasetType
-    dataset_type = db.Column(db.Enum(DatasetType), nullable=False)
+    dataset_type: DatasetType = db.Column(db.Enum(DatasetType), nullable=False)
     # Dataset.HPFPath
-    input_hpf_path = db.Column(db.String(500))
+    input_hpf_path: str = db.Column(db.String(500))
     # Dataset.Notes
-    notes = db.Column(db.Text)
+    notes: str = db.Column(db.Text)
     # RNASeqDataset.Condition (name TBD)
-    condition = db.Column(db.Enum(DatasetCondition), nullable=False)
-    extraction_protocol = db.Column(db.Enum(DatasetExtractionProtocol))
+    condition: DatasetCondition = db.Column(db.Enum(DatasetCondition), nullable=False)
+    extraction_protocol: DatasetExtractionProtocol = db.Column(db.Enum(DatasetExtractionProtocol))
     # RNASeqDataset.ExtractionMethod (guided dropdown or enum)
-    capture_kit = db.Column(db.String(50))
+    capture_kit: str = db.Column(db.String(50))
     # RNASeq.LibraryPrepMethod (guided dropdown or enum)
-    library_prep_method = db.Column(db.String(50))
-    library_prep_date = db.Column(db.Date)
-    read_length = db.Column(db.Integer)
-    read_type = db.Column(db.Enum(DatasetReadType))
-    sequencing_id = db.Column(db.String(50))
-    sequencing_date = db.Column(db.Date)
+    library_prep_method: str = db.Column(db.String(50))
+    library_prep_date: datetime = db.Column(db.Date)
+    read_length: int = db.Column(db.Integer)
+    read_type: DatasetReadType = db.Column(db.Enum(DatasetReadType))
+    sequencing_id: str = db.Column(db.String(50))
+    sequencing_date: datetime = db.Column(db.Date)
     # Uploaders.UploadCenter
-    sequencing_centre = db.Column(db.String(100))
-    batch_id = db.Column(db.String(50))
-    created = db.Column(db.DateTime, default=datetime.utcnow)
-    created_by = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
+    sequencing_centre: str = db.Column(db.String(100))
+    batch_id: str = db.Column(db.String(50))
+    created: datetime = db.Column(db.DateTime, default=datetime.utcnow)
+    created_by: int = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
     # Dataset.NotesLastUpdatedDate
-    updated = db.Column(db.DateTime, nullable=False, onupdate=datetime.now, default=datetime.utcnow)
+    updated: datetime = db.Column(db.DateTime, nullable=False, onupdate=datetime.now, default=datetime.utcnow)
     # Dataset.NotesLastUpdatedBy
-    updated_by = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
+    updated_by: int = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
 
     discriminator = db.Column(db.Enum('dataset', 'rnaseq_dataset'))
     __mapper_args__ = {
@@ -208,26 +213,28 @@ class Dataset(db.Model):
     analyses = db.relationship('Analysis', secondary=datasets_analyses_table, backref='datasets', lazy='dynamic')
 
 
+@dataclass
 class RNASeqDataset(Dataset):
     __tablename__ = 'rnaseq_dataset'
-    dataset_id = db.Column(db.Integer, db.ForeignKey('dataset.dataset_id', onupdate='cascade', ondelete='cascade'),
-                           primary_key=True)
+    dataset_id: int = db.Column(db.Integer,
+                                db.ForeignKey('dataset.dataset_id', onupdate='cascade', ondelete='cascade'),
+                                primary_key=True)
     # RNASeqDataset.RIN
-    RIN = db.Column(db.Float)
+    RIN: float = db.Column(db.Float)
     # RNASeqDataset.DV200
-    DV200 = db.Column(db.Integer)
+    DV200: int = db.Column(db.Integer)
     # RNASeqDataset.QubitRNAConcentration
-    concentration = db.Column(db.Float)
+    concentration: float = db.Column(db.Float)
     # RNASeqDataset.Sequencer (guided dropdown or enum)
-    sequencer = db.Column(db.String(50))
-    spike_in = db.Column(db.String(50))
+    sequencer: str = db.Column(db.String(50))
+    spike_in: str = db.Column(db.String(50))
 
     __mapper_args__ = {
         'polymorphic_identity': 'rnaseq_dataset'
     }
 
 
-class AnalysisState(Enum):
+class AnalysisState(str, Enum):
     Requested = 'Requested'
     Running = 'Running'
     Done = 'Done'
@@ -235,41 +242,51 @@ class AnalysisState(Enum):
     Cancelled = 'Cancelled'
 
 
+@dataclass
 class Analysis(db.Model):
     # Analysis.AnalysisID
-    analysis_id = db.Column(db.Integer, primary_key=True)
+    analysis_id: int = db.Column(db.Integer, primary_key=True)
     # AnalysisStatus.AnalysisStep
-    analysis_state = db.Column(db.Enum(AnalysisState), nullable=False)
-    pipeline_id = db.Column(db.Integer, db.ForeignKey('pipeline.pipeline_id', onupdate='cascade', ondelete='restrict'),
-                            nullable=False)
+    analysis_state: AnalysisState = db.Column(db.Enum(AnalysisState), nullable=False)
+    pipeline_id: int = db.Column(db.Integer,
+                                 db.ForeignKey('pipeline.pipeline_id', onupdate='cascade', ondelete='restrict'),
+                                 nullable=False)
     # Dataset.RunID
-    qsub_id = db.Column(db.Integer)
+    qsub_id: int = db.Column(db.Integer)
     # Analysis.ResultsDirectory
-    result_hpf_path = db.Column(db.String(500))
-    assignee = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'))
-    requester = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
+    result_hpf_path: str = db.Column(db.String(500))
+    assignee: int = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'))
+    requester: int = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
     # Analysis.RequestedDate
-    requested = db.Column(db.DateTime, nullable=False)
-    started = db.Column(db.DateTime)
-    finished = db.Column(db.DateTime)
-    notes = db.Column(db.Text)
+    requested: datetime = db.Column(db.DateTime, nullable=False)
+    started: datetime = db.Column(db.DateTime)
+    finished: datetime = db.Column(db.DateTime)
+    notes: str = db.Column(db.Text)
     # AnalysisStatus.UpdateDate
-    updated = db.Column(db.DateTime, nullable=False, onupdate=datetime.now)
+    updated: datetime = db.Column(db.DateTime, nullable=False, onupdate=datetime.now)
     # AnalysisStatus.UpdateUser
-    updated_by = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
+    updated_by: int = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
 
 
+@dataclass
 class Pipeline(db.Model):
-    pipeline_id = db.Column(db.Integer, primary_key=True)
-    pipeline_name = db.Column(db.String(50), nullable=False)
-    pipeline_version = db.Column(db.String(50), nullable=False)
+    pipeline_id: int = db.Column(db.Integer, primary_key=True)
+    pipeline_name: str = db.Column(db.String(50), nullable=False)
+    pipeline_version: str = db.Column(db.String(50), nullable=False)
+    supported = db.relationship('PipelineDatasets', backref='pipeline')
+
+    supported_types: List[DatasetType]
+    @property
+    def supported_types(self) -> List[DatasetType]:
+        return [x.supported_dataset for x in self.supported]
+
     __table_args__ = (
         db.UniqueConstraint('pipeline_name', 'pipeline_version'),
     )
 
 
 class PipelineDatasets(db.Model):
-    pipeline_id = db.Column(db.Integer, db.ForeignKey('pipeline.pipeline_id', onupdate='cascade', ondelete='restrict'),
-                            primary_key=True)
-    supported_dataset = db.Column(db.Enum(DatasetType), primary_key=True)
-
+    pipeline_id: int = db.Column(db.Integer,
+                                 db.ForeignKey('pipeline.pipeline_id', onupdate='cascade', ondelete='restrict'),
+                                 primary_key=True)
+    supported_dataset: DatasetType = db.Column(db.Enum(DatasetType), primary_key=True)

--- a/flask/app/models.py
+++ b/flask/app/models.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 
@@ -41,36 +42,37 @@ class Family(db.Model):
     participants = db.relationship('Participant', backref='family', lazy='dynamic')
 
 
-class Sex(Enum):
+class Sex(str, Enum):
     Male = 'Male'
     Female = 'Female'
     Other = 'Other'
 
 
-class ParticipantType(Enum):
+class ParticipantType(str, Enum):
     Proband = 'Proband'
     Mother = 'Mother'
     Father = 'Father'
     Sibling = 'Sibling'
 
 
+@dataclass
 class Participant(db.Model):
-    participant_id = db.Column(db.Integer, primary_key=True)
+    participant_id: int = db.Column(db.Integer, primary_key=True)
     family_id = db.Column(db.Integer, db.ForeignKey('family.family_id'), nullable=False)
     # Sample.SampleName
-    participant_codename = db.Column(db.String(50), nullable=False, unique=True)
+    participant_codename: str = db.Column(db.String(50), nullable=False, unique=True)
     # Sample.Gender
-    sex = db.Column(db.Enum(Sex), nullable=False)
+    sex: Sex = db.Column(db.Enum(Sex), nullable=False)
     # Sample.SampleType
-    participant_type = db.Column(db.Enum(ParticipantType), nullable=False)
+    participant_type: ParticipantType = db.Column(db.Enum(ParticipantType), nullable=False)
     # Sample.AffectedStatus
-    affected = db.Column(db.Boolean)
+    affected: bool = db.Column(db.Boolean)
     # Dataset.SolvedStatus
-    solved = db.Column(db.Boolean) #TODO uncomment and rebuild
-    notes = db.Column(db.Text)
-    created = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    solved: bool = db.Column(db.Boolean) #TODO uncomment and rebuild
+    notes: str = db.Column(db.Text)
+    created: datetime = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     created_by = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
-    updated = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+    updated: datetime = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
     updated_by = db.Column(db.Integer, db.ForeignKey('user.user_id', onupdate='cascade'), nullable=False)
     tissue_samples = db.relationship('TissueSample', backref='participant', lazy='dynamic')
 

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -189,7 +189,10 @@ def update_participants(participant_id: int):
     if not participant:
         return 'Not Found', 404
 
-    enum_error = mixin(participant, request.json, ['participant_codename', 'solved', 'sex', 'participant_type'])
+    enum_error = mixin(participant, request.json, [
+        'participant_codename', 'sex', 'participant_type',
+        'affected', 'solved', 'notes'
+    ])
     if enum_error:
         return enum_error, 400
 
@@ -204,9 +207,12 @@ def update_participants(participant_id: int):
         db.session.rollback()
         # SQLAlchemy wraps the underlying database error; extract just the message
         return err.orig.args[1], 400
-    except:
+    except exc.StatementError as err:
         db.session.rollback()
-        return 'Server error', 500
+        return str(err.orig), 400
+    except Exception as err:
+        db.session.rollback()
+        raise err
 
     return jsonify(participant)
 


### PR DESCRIPTION
Use dataclasses and string enums in SQLAlchemy models to automatically serialize with flask.jsonify
Add generic mixin function for PATCH use case and verify enums due to cryptic SQLAlchemy exception messages

Supersedes and closes #24 