### PR TITLE
Flask: PATCH /api/participants/:id, /api/datasets/:id, /api/analyses/:id in one function

### DIFF
--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -180,16 +180,13 @@ def mixin(entity: db.Model, json_mixin: Dict[str, Any], columns: List[str]) -> U
 
 
 @app.route('/api/<model_name>/<int:id>', methods = ['PATCH'])
-# eg. /api/analyses/1 for analysis table, /api/participants/1 for participants table, and so forth
 @login_required
 def update_db(model_name:str, id:int):
     if not request.json:
         return 'Request body must be JSON', 415
-    print(model_name)
-    #return(jsonify(model_name))
+
     editable_columns = []
 
-    # can these if statements be generalized?
     if model_name == 'participants':
         table = models.Participant.query.get(id)
         editable_columns = ['participant_codename', 'sex', 'participant_type',

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -190,7 +190,7 @@ def update_entity(model_name:str, id:int):
         editable_columns = ['participant_codename', 'sex', 'participant_type',
                              'affected', 'solved', 'notes']
     elif model_name == 'datasets':
-        table = models.Datasets.query.get(id)
+        table = models.Dataset.query.get(id)
         editable_columns = ['dataset_type', 'input_hpf_path', 'notes', 'condition',
                             'extraction_protocol', 'capture_kit', 'library_prep_method',
                             'library_prep_date', 'read_length', 'read_type', 'sequencing_id',
@@ -205,7 +205,11 @@ def update_entity(model_name:str, id:int):
     else:
         return 'Not Found', 404
 
+    if not table:
+         return 'Not Found', 404
+
     enum_error = mixin(table, request.json, editable_columns)
+    
     if enum_error:
         return enum_error, 400
 

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -181,31 +181,27 @@ def mixin(entity: db.Model, json_mixin: Dict[str, Any], columns: List[str]) -> U
 
 @app.route('/api/<model_name>/<int:id>', methods = ['PATCH'])
 @login_required
-def update_db(model_name:str, id:int):
+def update_entity(model_name:str, id:int):
     if not request.json:
         return 'Request body must be JSON', 415
-
-    editable_columns = []
 
     if model_name == 'participants':
         table = models.Participant.query.get(id)
         editable_columns = ['participant_codename', 'sex', 'participant_type',
-                        'affected', 'solved', 'notes']
+                             'affected', 'solved', 'notes']
     elif model_name == 'datasets':
         table = models.Datasets.query.get(id)
         editable_columns = ['dataset_type', 'input_hpf_path', 'notes', 'condition',
-                    'extraction_protocol', 'capture_kit', 'library_prep_method',
-                    'library_prep_date', 'read_length', 'read_type', 'sequencing_id',
-                    'sequencing_date', 'sequencing_centre', 'batch_id', 'discriminator'
-                    ]
+                            'extraction_protocol', 'capture_kit', 'library_prep_method',
+                            'library_prep_date', 'read_length', 'read_type', 'sequencing_id',
+                            'sequencing_date', 'sequencing_centre', 'batch_id', 'discriminator'
+                            ]
     elif model_name == 'analyses':
         table = models.Analysis.query.get(id)
-        editable_columns = [
-                    # I assume most of these will be coupled with the pipeline automation and should be editable
-                    'analysis_state', 'pipeline_id', 'qsub_id', 'result_hpf_path',
-                    'assignee','requester', 'requested',  'started','finished',
-                    'notes'
-                    ]
+        editable_columns = ['analysis_state', 'pipeline_id', 'qsub_id', 'result_hpf_path',
+                            'assignee','requester', 'requested',  'started','finished',
+                            'notes'
+                            ]
     else:
         return 'Not Found', 404
 


### PR DESCRIPTION
A lot of the code was reused between the different PATCH endpoints so I thought it would be better to have one generic view. I'm open to splitting this into individual routes for each table though.
