### PR TITLE
React: simplify date format in dataset & analysis table 

### DIFF
--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -329,7 +329,7 @@ export default function Analysis() {
                         { title: 'Pipeline', field: 'pipeline_id', type: 'string', editable: 'never', width: '8%' },
                         { title: 'Assignee', field: 'assignee', type: 'string', editable: 'never', width: '8%' },
                         { title: 'Requester', field: 'requester', type: 'string', editable: 'never', width: '8%' },
-                        { title: 'Updated', field: 'updated', type: 'string', editable: 'never' },
+                        { title: 'Updated', field: 'updated', type: 'date', editable: 'never', render: (rowData) => new Date(rowData.updated).toLocaleDateString() },
                         { title: 'Result HPF Path', field: 'result_hpf_path', type: 'string' },
                         { title: 'Status', field: 'state', type: 'string', editable: 'never', defaultFilter: chipFilter },
                         { title: 'Notes', field: 'notes', type: 'string', width: '30%', /* render: renderNotes, */

--- a/react/src/pages/datasets/DatasetTable.tsx
+++ b/react/src/pages/datasets/DatasetTable.tsx
@@ -97,7 +97,7 @@ export default function DatasetTable() {
                     )},
                     // { title: 'Created', field: 'created', type: 'datetime' },
                     // { title: 'Created by', field: 'created_by' },
-                    { title: 'Updated', field: 'updated', type: 'datetime', editable: 'never' },
+                    { title: 'Updated', field: 'updated', type: 'date', editable: 'never', render: (rowData) => new Date(rowData.updated).toLocaleDateString() },
                     { title: 'Updated By', field: 'updated_by', editable: 'never' },
                 ]}
                 data={datasets}


### PR DESCRIPTION
Reduced datetime format to MM/DD/YYYY in dataset table and analysis table. (there is no update date column in the participant table)
MM/DD/YYYY is used instead of YYYY-MM-DD because there is a built-in method that can do this.

Closes #82 