### PR TITLE
ISO Date formatting (#82) and editable cells (#79)

### DIFF
--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -9,6 +9,7 @@ import CancelAnalysisDialog from './CancelAnalysisDialog';
 import AnalysisInfoDialog from './AnalysisInfoDialog';
 import AddAnalysisAlert from './AddAnalysisAlert';
 import SetAssigneeDialog from './SetAssigneeDialog';
+import { formatDateString } from '../utils';
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -176,6 +177,8 @@ const refreshTimeDelay = 1000 * 60;
  */
 function jsonToAnalysisRows(data: Array<any>): AnalysisRow[] {
     const rows: AnalysisRow[] = data.map((row, index, arr) => {
+        row.updated = formatDateString(row.updated);
+
         switch (row.analysis_state) {
             case 'Requested':
                 row.state = PipelineStatus.PENDING;

--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -467,6 +467,12 @@ export default function Analysis() {
                                 resolve();
                             })
                     }}
+                    cellEditable={{
+                        onCellEditApproved: (newValue, oldValue, row, columnDef) =>
+                            new Promise((resolve, reject) => {
+                                setTimeout(resolve, 2000);
+                            })
+                    }}
                     components={{
                         Toolbar: props => (
                             <div>

--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -9,7 +9,7 @@ import CancelAnalysisDialog from './CancelAnalysisDialog';
 import AnalysisInfoDialog from './AnalysisInfoDialog';
 import AddAnalysisAlert from './AddAnalysisAlert';
 import SetAssigneeDialog from './SetAssigneeDialog';
-import { formatDateString } from '../utils';
+import { emptyCellValue, formatDateString } from '../utils';
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -333,9 +333,9 @@ export default function Analysis() {
                         { title: 'Assignee', field: 'assignee', type: 'string', editable: 'never', width: '8%' },
                         { title: 'Requester', field: 'requester', type: 'string', editable: 'never', width: '8%' },
                         { title: 'Updated', field: 'updated', type: 'string', editable: 'never', render: rowData => formatDateString(rowData.updated) },
-                        { title: 'Result HPF Path', field: 'result_hpf_path', type: 'string', emptyValue: '<empty>' },
+                        { title: 'Result HPF Path', field: 'result_hpf_path', type: 'string', emptyValue: emptyCellValue },
                         { title: 'Status', field: 'state', type: 'string', editable: 'never', defaultFilter: chipFilter },
-                        { title: 'Notes', field: 'notes', type: 'string', width: '30%', emptyValue: '<empty>',
+                        { title: 'Notes', field: 'notes', type: 'string', width: '30%', emptyValue: emptyCellValue,
                         editComponent: props => (
                             <TextField
                             multiline

--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -3,7 +3,7 @@ import { useParams, useHistory, useLocation } from 'react-router';
 import { makeStyles } from '@material-ui/core/styles';
 import { Chip, IconButton, TextField, Tooltip, Typography, Container } from '@material-ui/core';
 import { Cancel, Description, Add, Visibility, PlayArrow, PersonPin } from '@material-ui/icons';
-import MaterialTable, { MTableToolbar } from 'material-table';
+import MaterialTable, { MTableCell, MTableToolbar } from 'material-table';
 import Title from '../Title';
 import CancelAnalysisDialog from './CancelAnalysisDialog';
 import AnalysisInfoDialog from './AnalysisInfoDialog';
@@ -333,9 +333,9 @@ export default function Analysis() {
                         { title: 'Assignee', field: 'assignee', type: 'string', editable: 'never', width: '8%' },
                         { title: 'Requester', field: 'requester', type: 'string', editable: 'never', width: '8%' },
                         { title: 'Updated', field: 'updated', type: 'string', editable: 'never' },
-                        { title: 'Result HPF Path', field: 'result_hpf_path', type: 'string' },
+                        { title: 'Result HPF Path', field: 'result_hpf_path', type: 'string', emptyValue: '<empty>' },
                         { title: 'Status', field: 'state', type: 'string', editable: 'never', defaultFilter: chipFilter },
-                        { title: 'Notes', field: 'notes', type: 'string', width: '30%', /* render: renderNotes, */
+                        { title: 'Notes', field: 'notes', type: 'string', width: '30%', emptyValue: '<empty>',
                         editComponent: props => (
                             <TextField
                             multiline
@@ -471,7 +471,8 @@ export default function Analysis() {
                         onCellEditApproved: (newValue, oldValue, row, columnDef) =>
                             new Promise((resolve, reject) => {
                                 setTimeout(resolve, 2000);
-                            })
+                            }),
+
                     }}
                     components={{
                         Toolbar: props => (
@@ -487,8 +488,7 @@ export default function Analysis() {
                                 </div>
                             </div>
                             )
-                        }
-                    }
+                    }}
                 />
             </Container>
         </main>

--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -332,7 +332,7 @@ export default function Analysis() {
                         { title: 'Pipeline', field: 'pipeline_id', type: 'string', editable: 'never', width: '8%' },
                         { title: 'Assignee', field: 'assignee', type: 'string', editable: 'never', width: '8%' },
                         { title: 'Requester', field: 'requester', type: 'string', editable: 'never', width: '8%' },
-                        { title: 'Updated', field: 'updated', type: 'string', editable: 'never' },
+                        { title: 'Updated', field: 'updated', type: 'string', editable: 'never', render: rowData => formatDateString(rowData.updated) },
                         { title: 'Result HPF Path', field: 'result_hpf_path', type: 'string', emptyValue: '<empty>' },
                         { title: 'Status', field: 'state', type: 'string', editable: 'never', defaultFilter: chipFilter },
                         { title: 'Notes', field: 'notes', type: 'string', width: '30%', emptyValue: '<empty>',

--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -468,9 +468,30 @@ export default function Analysis() {
                             })
                     }}
                     cellEditable={{
-                        onCellEditApproved: (newValue, oldValue, row, columnDef) =>
+                        onCellEditApproved: (newValue, oldValue, editedRow, columnDef) =>
                             new Promise((resolve, reject) => {
-                                setTimeout(resolve, 2000);
+                                const dataUpdate = [...rows];
+                                const index = dataUpdate.findIndex((row, index, obj) => {
+                                    return row.analysis_id === editedRow.analysis_id;
+                                });
+                                const newRow: AnalysisRow = { ...dataUpdate[index] };
+
+                                if (newValue === '')
+                                    newValue = null;
+
+                                switch (columnDef.field) {
+                                    case 'result_hpf_path':
+                                        newRow.result_hpf_path = newValue;
+                                        break;
+                                    case 'notes':
+                                        newRow.notes = newValue;
+                                        break;
+                                    default:
+                                        break;
+                                }
+                                dataUpdate[index] = newRow;
+                                setRows(dataUpdate);
+                                resolve();
                             }),
 
                     }}

--- a/react/src/pages/dashboard/AnalysisTable.tsx
+++ b/react/src/pages/dashboard/AnalysisTable.tsx
@@ -35,6 +35,7 @@ export default function AnalysisTable({ participantID }: ParticipantInfoProp) {
                 paging: false,
                 selection: false,
                 search: false,
+                padding: "dense"
             }}
         />
     );

--- a/react/src/pages/dashboard/AnalysisTable.tsx
+++ b/react/src/pages/dashboard/AnalysisTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import MaterialTable from 'material-table';
 import { getAnalyses } from './MockData';
+import { formatDateString } from '../utils';
 
 interface ParticipantInfoProp {
     participantID: string
@@ -22,11 +23,11 @@ export default function AnalysisTable({ participantID }: ParticipantInfoProp) {
                 { title: 'Result HPF Path', field: 'resultHpfPath' },
                 { title: 'Assignee', field: 'assignee' },
                 { title: 'Requester', field: 'requester' },
-                { title: 'Requested', field: 'requested' },
-                { title: 'Started', field: 'started' },
-                { title: 'Finished', field: 'finished' },
+                { title: 'Requested', field: 'requested', render: rowData => formatDateString(rowData.requested) },
+                { title: 'Started', field: 'started', render: rowData => formatDateString(rowData.started) },
+                { title: 'Finished', field: 'finished', render: rowData => formatDateString(rowData.finished) },
                 { title: 'Notes', field: 'notes' },
-                { title: 'Updated', field: 'updated' },
+                { title: 'Updated', field: 'updated', render: rowData => formatDateString(rowData.updated) },
                 { title: 'Updated By', field: 'updatedBy' },
             ]}
             data={analyses}

--- a/react/src/pages/dashboard/SampleTable.tsx
+++ b/react/src/pages/dashboard/SampleTable.tsx
@@ -3,6 +3,7 @@ import { makeStyles } from '@material-ui/core';
 import MaterialTable from 'material-table';
 import { getSamplesAndDatasets } from './MockData';
 import DatasetAccordions from './DatasetAccordion'
+import { formatDateString } from '../utils';
 
 const useStyles = makeStyles(theme => ({
     table: {
@@ -29,9 +30,9 @@ export default function SamplesTable({ participantID }: ParticipantInfoProp) {
                     { title: 'Sample Type', field: 'sampleType' },
                     { title: 'Tissue Processing', field: 'tissueProcessing' },
                     { title: 'Notes', field: 'notes' },
-                    { title: 'Creation Time', field: 'created' },
+                    { title: 'Creation Time', field: 'created', render: rowData => formatDateString(rowData.created) },
                     { title: 'Create By', field: 'createBy' },
-                    { title: 'Update Time', field: 'updated' },
+                    { title: 'Update Time', field: 'updated', render: rowData => formatDateString(rowData.updated) },
                     { title: 'Updated By', field: 'updatedBy' },
                 ]}
                 data={info.samples}

--- a/react/src/pages/dashboard/SampleTable.tsx
+++ b/react/src/pages/dashboard/SampleTable.tsx
@@ -16,7 +16,7 @@ interface ParticipantInfoProp {
 
 export default function SamplesTable({ participantID }: ParticipantInfoProp) {
     const classes = useStyles();
-    
+
     //fetch participant samples and datasets for each sample
     const info = getSamplesAndDatasets(participantID);
 
@@ -41,8 +41,9 @@ export default function SamplesTable({ participantID }: ParticipantInfoProp) {
                     paging: false,
                     selection: false,
                     search: false,
+                    padding: "dense"
                 }}
-            />            
+            />
         </div>
     );
 }

--- a/react/src/pages/datasets/DatasetTable.tsx
+++ b/react/src/pages/datasets/DatasetTable.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { makeStyles, Chip, IconButton, TextField } from '@material-ui/core';
 import { PlayArrow, Delete, Cancel } from '@material-ui/icons';
 import MaterialTable, { MTableToolbar } from 'material-table';
-import { toKeyValue, KeyValue } from "../utils";
+import { toKeyValue, KeyValue, formatDateString } from "../utils";
 import AnalysisRunnerDialog, { Pipeline } from './AnalysisRunnerDialog';
 
 export interface Dataset {
@@ -14,9 +14,9 @@ export interface Dataset {
     input_hpf_path?: string;
     notes?: string;
     condition: string;
-    created: Date;
+    created: string; // date
     created_by: string;
-    updated: Date;
+    updated: string; // date
     updated_by: string;
 }
 
@@ -57,7 +57,12 @@ export default function DatasetTable() {
         });
         fetch("/api/datasets").then(async response => {
             if (response.ok) {
-                setDatasets(await response.json());
+                const data = await response.json() as any[];
+                data.forEach((row, index, arr) => {
+                    row.updated = formatDateString(row.updated);
+                    return row;
+                })
+                setDatasets(data);
             } else {
                 console.error(`GET /api/datasets failed with ${response.status}: ${response.statusText}`);
             }
@@ -97,7 +102,7 @@ export default function DatasetTable() {
                     )},
                     // { title: 'Created', field: 'created', type: 'datetime' },
                     // { title: 'Created by', field: 'created_by' },
-                    { title: 'Updated', field: 'updated', type: 'datetime', editable: 'never' },
+                    { title: 'Updated', field: 'updated', type: 'string', editable: 'never' },
                     { title: 'Updated By', field: 'updated_by', editable: 'never' },
                 ]}
                 data={datasets}

--- a/react/src/pages/datasets/DatasetTable.tsx
+++ b/react/src/pages/datasets/DatasetTable.tsx
@@ -111,7 +111,8 @@ export default function DatasetTable() {
                     pageSize: 10,
                     selection: true,
                     filtering: true,
-                    search: false
+                    search: false,
+                    padding: "dense"
                 }}
                 editable={{
                     onRowUpdate: async (newDataset, oldDataset) => {

--- a/react/src/pages/datasets/DatasetTable.tsx
+++ b/react/src/pages/datasets/DatasetTable.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { makeStyles, Chip, IconButton, TextField } from '@material-ui/core';
 import { PlayArrow, Delete, Cancel } from '@material-ui/icons';
-import MaterialTable, { MTableToolbar } from 'material-table';
+import MaterialTable, { MTableCell, MTableToolbar } from 'material-table';
 import { toKeyValue, KeyValue, formatDateString } from "../utils";
 import AnalysisRunnerDialog, { Pipeline } from './AnalysisRunnerDialog';
 
@@ -58,10 +58,6 @@ export default function DatasetTable() {
         fetch("/api/datasets").then(async response => {
             if (response.ok) {
                 const data = await response.json() as any[];
-                data.forEach((row, index, arr) => {
-                    row.updated = formatDateString(row.updated);
-                    return row;
-                })
                 setDatasets(data);
             } else {
                 console.error(`GET /api/datasets failed with ${response.status}: ${response.statusText}`);
@@ -102,7 +98,7 @@ export default function DatasetTable() {
                     )},
                     // { title: 'Created', field: 'created', type: 'datetime' },
                     // { title: 'Created by', field: 'created_by' },
-                    { title: 'Updated', field: 'updated', type: 'string', editable: 'never' },
+                    { title: 'Updated', field: 'updated', type: 'string', editable: 'never', render: rowData => formatDateString(rowData.updated) },
                     { title: 'Updated By', field: 'updated_by', editable: 'never' },
                 ]}
                 data={datasets}

--- a/react/src/pages/datasets/DatasetTable.tsx
+++ b/react/src/pages/datasets/DatasetTable.tsx
@@ -133,6 +133,36 @@ export default function DatasetTable() {
                         }
                     }
                 }}
+                cellEditable={{
+                    onCellEditApproved: (newValue, oldValue, editedRow, columnDef) =>
+                            new Promise((resolve, reject) => {
+                                const dataUpdate = [...datasets];
+                                const index = dataUpdate.findIndex((row, index, obj) => {
+                                    return row.dataset_id === editedRow.dataset_id;
+                                });
+                                const newRow: Dataset = { ...dataUpdate[index] };
+
+                                if (newValue === '')
+                                    newValue = null;
+
+                                switch (columnDef.field) {
+                                    case 'dataset_type':
+                                        newRow.dataset_type = newValue;
+                                        break;
+                                    case 'condition':
+                                        newRow.condition = newValue;
+                                        break;
+                                    case 'notes':
+                                        newRow.notes = newValue;
+                                        break;
+                                    default:
+                                        break;
+                                }
+                                dataUpdate[index] = newRow;
+                                setDatasets(dataUpdate);
+                                resolve();
+                            }),
+                }}
                 components={{
                     Toolbar: props => (
                         <div>

--- a/react/src/pages/datasets/DatasetTable.tsx
+++ b/react/src/pages/datasets/DatasetTable.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { makeStyles, Chip, IconButton, TextField } from '@material-ui/core';
 import { PlayArrow, Delete, Cancel } from '@material-ui/icons';
 import MaterialTable, { MTableCell, MTableToolbar } from 'material-table';
-import { toKeyValue, KeyValue, formatDateString } from "../utils";
+import { toKeyValue, KeyValue, formatDateString, emptyCellValue } from "../utils";
 import AnalysisRunnerDialog, { Pipeline } from './AnalysisRunnerDialog';
 
 export interface Dataset {
@@ -85,9 +85,9 @@ export default function DatasetTable() {
                     { title: 'Participant', field: 'participant_codename', editable: 'never' },
                     { title: 'Family', field: 'family_codename', editable: 'never' },
                     { title: 'Tissue Sample', field: 'tissue_sample_type', editable: 'never', lookup: tissueSampleTypes },
-                    { title: 'Dataset Type', field: 'dataset_type', defaultFilter: datasetTypeFilter, lookup: datasetTypes },
-                    { title: 'Condition', field: 'condition', lookup: conditions },
-                    { title: 'Notes', field: 'notes', editComponent: props => (
+                    { title: 'Dataset Type', field: 'dataset_type', defaultFilter: datasetTypeFilter, lookup: datasetTypes, emptyValue: emptyCellValue },
+                    { title: 'Condition', field: 'condition', lookup: conditions, emptyValue: emptyCellValue },
+                    { title: 'Notes', field: 'notes', emptyValue: emptyCellValue, editComponent: props => (
                         <TextField
                             multiline
                             value={props.value}

--- a/react/src/pages/upload/FilesTable.tsx
+++ b/react/src/pages/upload/FilesTable.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect }  from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Chip from '@material-ui/core/Chip';
 import MaterialTable, { MTableToolbar } from 'material-table';
+import { formatDateString } from '../utils';
 
 
 const useStyles = makeStyles(theme => ({
@@ -33,7 +34,7 @@ export default function FilesTable() {
             setIserror(true)
           })
       }, [])
-    
+
 
     return (
         <MaterialTable

--- a/react/src/pages/utils.tsx
+++ b/react/src/pages/utils.tsx
@@ -60,3 +60,5 @@ export function formatDateString(date: string) {
     }
     return date;
 }
+
+export const emptyCellValue = "<empty>";

--- a/react/src/pages/utils.tsx
+++ b/react/src/pages/utils.tsx
@@ -27,3 +27,16 @@ export function toKeyValue(items: string[]) {
         return map;
     }, Object.create(null));
 }
+
+/**
+ * Return a date string in the format "YYYY-MM-DD"
+ */
+export function formatDateString(date: string) {
+    let d = new Date(date);
+    let [year, month, day] = ['' + d.getFullYear(), '' + d.getMonth(), '' + d.getDay()];
+    if (month.length < 2)
+        month = '0' + month;
+    if (day.length < 2)
+        day = '0' + day;
+    return [year, month, day].join('-');
+}

--- a/react/src/pages/utils.tsx
+++ b/react/src/pages/utils.tsx
@@ -28,15 +28,35 @@ export function toKeyValue(items: string[]) {
     }, Object.create(null));
 }
 
+const months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec"
+];
+
 /**
- * Return a date string in the format "YYYY-MM-DD"
+ * Return a date string in the format "YYYY-MM-DD", if possible.
+ *
+ * @param {string} date Datestring of the form: "Day, DD Mon YYYY HH:MM:SS GMT"
  */
 export function formatDateString(date: string) {
-    let d = new Date(date);
-    let [year, month, day] = ['' + d.getFullYear(), '' + d.getMonth(), '' + d.getDay()];
-    if (month.length < 2)
-        month = '0' + month;
-    if (day.length < 2)
-        day = '0' + day;
-    return [year, month, day].join('-');
+    // Pretty general datestring because we trust the server to send a good one
+    const regex = /^[A-Z][a-z]{2}, (\d{2}) ([A-Z][a-z]{2}) (\d{4}) \d{2}:\d{2}:\d{2} GMT$/
+    const result = regex.exec(date);
+    if (result) {
+        let [year, month, day] = [result[3], '' + (months.indexOf(result[2]) + 1), result[1]];
+        if (month.length < 2)
+            month = '0' + month;
+        return [year, month, day].join('-');
+    }
+    return date;
 }


### PR DESCRIPTION
* Change rendering of datetime strings to ISO format (closes #82)
* Add editable cells to Analysis table (closes #79) (note: changes are local; mutations are on different branch)
* Enable dense padding for dataset, dashboard, analysis tables