### PR TITLE
React: hook up analysis table rows, set assignee

### DIFF
--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -446,7 +446,6 @@ export default function Analysis() {
                         onRowUpdate: (newData, oldData) =>
                             new Promise((resolve, reject) => {
                                 // TODO: Send PATCH here for editing notes or path
-
                                 const dataUpdate = [...rows];
                                 // find the row; assume analysis_id is unique
                                 const index = dataUpdate.findIndex((row, index, obj) => {
@@ -459,7 +458,26 @@ export default function Analysis() {
                                 newRow.notes = newData.notes;
                                 newRow.result_hpf_path = newData.result_hpf_path;
                                 dataUpdate[index] = newRow;
-                                setRows(dataUpdate);
+
+                                fetch('/api/analyses/' + newRow.analysis_id, {
+                                    method: "PATCH",
+                                    body: JSON.stringify(newRow)
+                                })
+                                .then(response => {
+                                    console.log(response);
+                                    return response.json();
+                                })
+                                .then(resData => { // success
+                                    console.log("Successful PATCH");
+                                    setRows(dataUpdate);
+                                    resolve();
+                                })
+                                .catch(error => { // error
+                                    console.error(error);
+                                    reject(error);
+                                })
+
+
 
                                 resolve();
                             })

--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -9,7 +9,6 @@ import CancelAnalysisDialog from './CancelAnalysisDialog';
 import AnalysisInfoDialog from './AnalysisInfoDialog';
 import AddAnalysisAlert from './AddAnalysisAlert';
 import SetAssigneeDialog from './SetAssigneeDialog';
-import { rowToJSON } from '../utils';
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -460,12 +459,9 @@ export default function Analysis() {
                                 newRow.result_hpf_path = newData.result_hpf_path;
                                 dataUpdate[index] = newRow;
 
-                                console.log("Sending PATCH request...");
-                                console.log(rowToJSON(newRow));
-
                                 fetch('/api/analyses/'+newRow.analysis_id, {
                                     method: "PATCH",
-                                    body: rowToJSON(newRow),
+                                    body: JSON.stringify({ notes: newRow.notes, result_hpf_path: newRow.result_hpf_path }),
                                     headers: {
                                         'Content-Type': 'application/json'
                                     }
@@ -482,10 +478,6 @@ export default function Analysis() {
                                     console.error(error);
                                     reject(error);
                                 })
-
-
-
-                                resolve();
                             })
                     }}
                     components={{

--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -303,7 +303,26 @@ export default function Analysis() {
                     affectedRows={activeRows}
                     open={assignment}
                     onClose={() => { setAssignment(false); }}
-                    onSubmit={(username) => {
+                    onSubmit={async (username) => {
+                        activeRows.forEach(async (row) => {
+                            const response = await fetch('/api/analyses/'+row.analysis_id, {
+                                method: "PATCH",
+                                body: JSON.stringify({ assignee: username }),
+                                headers: {
+                                    'Content-Type': 'application/json'
+                                }
+                            });
+                            if (response.ok) {
+                                const newRow = await response.json();
+                                setRows(rows.map((oldRow) =>
+                                    oldRow.analysis_id === newRow.analysis_id
+                                    ? { ...oldRow, ...newRow }
+                                    : oldRow
+                                ));
+                            } else {
+                                console.error(response);
+                            }
+                        })
                         // TODO: PATCH goes here for setting assignees
 
                         // If successful...

--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -304,7 +304,7 @@ export default function Analysis() {
                     open={assignment}
                     onClose={() => { setAssignment(false); }}
                     onSubmit={async (username) => {
-                        activeRows.forEach(async (row) => {
+                        for (const row of activeRows) {
                             const response = await fetch('/api/analyses/'+row.analysis_id, {
                                 method: "PATCH",
                                 body: JSON.stringify({ assignee: username }),
@@ -322,20 +322,7 @@ export default function Analysis() {
                             } else {
                                 console.error(response);
                             }
-                        })
-                        // TODO: PATCH goes here for setting assignees
-
-                        // If successful...
-                        const newRows = [...rows];
-                        newRows.forEach((row, index, arr) => {
-                            if (row.selected) {
-                                const newRow: AnalysisRow = { ...newRows[index] };
-                                newRow.assignee = username;
-                                newRows[index] = newRow;
-                            }
-                        });
-
-                        setRows(newRows);
+                        }
                         setAssignment(false);
 
                     }}

--- a/react/src/pages/analysis/Analysis.tsx
+++ b/react/src/pages/analysis/Analysis.tsx
@@ -9,6 +9,7 @@ import CancelAnalysisDialog from './CancelAnalysisDialog';
 import AnalysisInfoDialog from './AnalysisInfoDialog';
 import AddAnalysisAlert from './AddAnalysisAlert';
 import SetAssigneeDialog from './SetAssigneeDialog';
+import { rowToJSON } from '../utils';
 
 const useStyles = makeStyles(theme => ({
     root: {
@@ -459,16 +460,21 @@ export default function Analysis() {
                                 newRow.result_hpf_path = newData.result_hpf_path;
                                 dataUpdate[index] = newRow;
 
-                                fetch('/api/analyses/' + newRow.analysis_id, {
+                                console.log("Sending PATCH request...");
+                                console.log(rowToJSON(newRow));
+
+                                fetch('/api/analyses/'+newRow.analysis_id, {
                                     method: "PATCH",
-                                    body: JSON.stringify(newRow)
+                                    body: rowToJSON(newRow),
+                                    headers: {
+                                        'Content-Type': 'application/json'
+                                    }
                                 })
                                 .then(response => {
                                     console.log(response);
                                     return response.json();
                                 })
                                 .then(resData => { // success
-                                    console.log("Successful PATCH");
                                     setRows(dataUpdate);
                                     resolve();
                                 })

--- a/react/src/pages/utils.tsx
+++ b/react/src/pages/utils.tsx
@@ -27,11 +27,3 @@ export function toKeyValue(items: string[]) {
         return map;
     }, Object.create(null));
 }
-
-/**
- * Returns JSON string of table row with material-table metadata removed.
- */
-export function rowToJSON(row: any): string {
-    var newRow = Object.assign({}, {...row}, {selected: undefined, tableData: undefined});
-    return JSON.stringify(newRow);
-}

--- a/react/src/pages/utils.tsx
+++ b/react/src/pages/utils.tsx
@@ -27,3 +27,11 @@ export function toKeyValue(items: string[]) {
         return map;
     }, Object.create(null));
 }
+
+/**
+ * Returns JSON string of table row with material-table metadata removed.
+ */
+export function rowToJSON(row: any): string {
+    var newRow = Object.assign({}, {...row}, {selected: undefined, tableData: undefined});
+    return JSON.stringify(newRow);
+}


### PR DESCRIPTION
For #80, however we may need a new PATCH endpoint for patching multiple analyses in one request (for set assignee, start analysis, cancel analysis). Only option as of now is to send 1 PATCH request for every row selected, which isn't great.