### PR TITLE
GET /api/tissue_samples/:id

### DIFF
--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -772,3 +772,29 @@ def post_analyses():
     transaction_or_abort(db.session.commit)
 
     return jsonify(obj)
+
+
+@app.route("/api/tissue_samples/<int:id>", methods=["GET"])
+@login_required
+def get_tissue_sample(id: int):
+    tissue_sample = (
+        models.TissueSample.query.filter_by(tissue_sample_id=id)
+        .options(
+            joinedload(models.TissueSample.datasets)
+        )
+        .one_or_none()
+    )
+    if not tissue_sample:
+        return "Not Found", 404
+    else:
+        return jsonify(
+            {
+                **asdict(tissue_sample),
+                "datasets": [
+                    {
+                        **asdict(dataset)
+                    }
+                    for dataset in tissue_sample.datasets
+                ]
+            }
+        )

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -779,9 +779,7 @@ def post_analyses():
 def get_tissue_sample(id: int):
     tissue_sample = (
         models.TissueSample.query.filter_by(tissue_sample_id=id)
-        .options(
-            joinedload(models.TissueSample.datasets)
-        )
+        .options(joinedload(models.TissueSample.datasets))
         .one_or_none()
     )
     if not tissue_sample:
@@ -790,11 +788,6 @@ def get_tissue_sample(id: int):
         return jsonify(
             {
                 **asdict(tissue_sample),
-                "datasets": [
-                    {
-                        **asdict(dataset)
-                    }
-                    for dataset in tissue_sample.datasets
-                ]
+                "datasets": tissue_sample.datasets,
             }
         )


### PR DESCRIPTION
closes #136

@kevinlul Did we want other fields, such as participant codename, family codename, etc?