### PR TITLE
Flask: add unit tests for all endpoints

### DIFF
--- a/flask/app/__init__.py
+++ b/flask/app/__init__.py
@@ -4,10 +4,6 @@ from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 
-logging.basicConfig()
-logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
-logging.getLogger("sqlalchemy.pool").setLevel(logging.INFO)
-
 db = SQLAlchemy()
 login = LoginManager()
 migrate = Migrate()
@@ -22,6 +18,11 @@ def create_app(config):
     app = Flask(__name__)
 
     app.config.from_object(config)
+
+    if config.SQLALCHEMY_LOG:
+        logging.basicConfig()
+        logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
+        logging.getLogger("sqlalchemy.pool").setLevel(logging.INFO)
 
     flask_logging.create_logger(app)
     login.session_protection = "strong"

--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -142,9 +142,8 @@ def get_analysis(id: int):
 @app.route("/api/analyses", methods=["POST"])
 @login_required
 def create_analysis():
-
     if not request.json:
-        return "Request body must be JSON!", 400
+        return "Request body must be JSON!", 415
     try:
         dts_pks = request.json["datasets"]
     except KeyError:

--- a/flask/app/config.py
+++ b/flask/app/config.py
@@ -23,12 +23,3 @@ class Config(object):
     )
     MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE")
     TESTING = False
-
-
-class DevConfig(Config):
-    """
-    Development config settings.
-    """
-
-    FLASK_ENV = "development"
-    DEBUG = True

--- a/flask/app/config.py
+++ b/flask/app/config.py
@@ -11,6 +11,7 @@ class Config(object):
         "ST_DATABASE_URI", "mysql+pymysql://admin:admin@localhost/st2020"
     )
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_LOG = True
     DEFAULT_ADMIN = os.getenv("ST_DEFAULT_ADMIN", "admin")
     DEFAULT_ADMIN_EMAIL = os.getenv(
         "ST_DEFAULT_EMAIL", "admin@sampletracker.ccm.sickkids.ca"

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -196,7 +196,7 @@ def delete_dataset(id: int):
 @login_required
 def create_dataset():
     if not request.json:
-        return "Request body must be JSON", 400
+        return "Request body must be JSON", 415
 
     dataset_type = request.json.get("dataset_type")
     if not dataset_type:

--- a/flask/app/families.py
+++ b/flask/app/families.py
@@ -188,9 +188,10 @@ def update_family(id: int):
 
 @app.route("/api/families", methods=["POST"])
 @login_required
+@check_admin
 def create_family():
     if not request.json:
-        return "Request body must be JSON", 400
+        return "Request body must be JSON", 415
 
     try:
         updated_by = current_user.user_id

--- a/flask/app/participants.py
+++ b/flask/app/participants.py
@@ -151,10 +151,10 @@ def update_participant(id: int):
 
 @app.route("/api/participants", methods=["POST"])
 @login_required
+@routes.check_admin
 def create_participant():
-
     if not request.json:
-        return "Request body must be JSON", 400
+        return "Request body must be JSON", 415
 
     try:
         updated_by = current_user.user_id

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -373,6 +373,7 @@ def bulk_update():
         )
 
         if enum_error:
+            db.session.rollback()
             return f"Error on line {str(i + 1)} - " + enum_error, 400
 
         ptp_objs = models.Participant(
@@ -404,6 +405,7 @@ def bulk_update():
             )
 
             if enum_error:
+                db.session.rollback()
                 return f"Error on line {str(i + 1)}: " + enum_error, 400
 
             tis_objs = models.TissueSample(
@@ -427,6 +429,7 @@ def bulk_update():
             enum_error = enum_validate(models.Dataset, row, editable_dict["dataset"])
 
             if enum_error:
+                db.session.rollback()
                 return f"Error on line {str(i + 1)} - " + enum_error, 400
 
             dts_objs = models.Dataset(

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -548,7 +548,7 @@ def delete_tissue_sample(id: int):
 @check_admin
 def create_tissue_sample():
     if not request.json:
-        return "Request body must be JSON", 400
+        return "Request body must be JSON", 415
 
     tissue_sample_type = request.json.get("tissue_sample_type")
     if not tissue_sample_type:

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -84,9 +84,9 @@ def logout():
 def check_admin(handler):
     @wraps(handler)
     def decorated_handler(*args, **kwargs):
-        if False:
-            return "Unauthorized", 401
-        return handler(*args, **kwargs)
+        if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
+            return handler(*args, **kwargs)
+        return "Unauthorized", 401
 
     return decorated_handler
 

--- a/flask/tests/badsamplecsv.csv
+++ b/flask/tests/badsamplecsv.csv
@@ -1,0 +1,7 @@
+participant_codename,family_codename,tissue_sample_type,dataset_type,affected,participant_type,sex,month_of_birth,solved,condition,extraction_protocol,capture_kit,library_prep_method,read_length,read_type,sequencing_id,sequencing_date,sequencing_centre,batch_id
+PTP01,FAM01,RANDOM NONESENSE
+PTP02,FAM01,Blood,WES,FALSE,Mother,Female,2012-01-01,FALSE,GermLine,Something,,,,SingleEnd,,,,
+PTP03,FAM01,Blood,WES,TRUE,Proband,Female,2000-06-01,FALSE,GermLine,Something,,,,PairedEnd,,,,
+BBB01,FAM02,Saliva,WES,FALSE,Mother,Male,1990-08-01,TRUE,GermLine,Something,,,,SingleEnd,,,,
+BBB02,FAM02,Saliva,WGS,TRUE,Father,Male,1970-01-01,TRUE,GermLine,Something,,,,PairedEnd,,,,
+BBB03,FAM03,Saliva,WGS,TRUE,Proband,Female,1980-01-01,TRUE,GermLine,Something,,,,SingleEnd,,,,,

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -22,6 +22,7 @@ class TestConfig(Config):
     )
     MINIO_ACCESS_KEY = os.getenv("TEST_MINIO_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE")
     TESTING = True
+    LOGIN_DISABLED=False
 
 
 @pytest.fixture(scope="session")

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -222,6 +222,7 @@ def test_database(client):
 @pytest.fixture
 def login_as(client):
     def login(identity: str) -> None:
+        client.post("/api/logout", json={"useless": "why"})
         assert (
             client.post(
                 "/api/login",

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -15,6 +15,7 @@ class TestConfig(Config):
     SQLALCHEMY_DATABASE_URI = os.getenv(
         "TEST_ST_DATABASE_URI", "mysql+pymysql://admin:admin@localhost/st2020testing"
     )
+    SQLALCHEMY_LOG = False
     MINIO_ENDPOINT = os.getenv("TEST_MINIO_ENDPOINT", "localhost:9000")
     MINIO_SECRET_KEY = os.getenv(
         "TEST_MINIO_SECRET_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -218,8 +218,17 @@ def test_database(client):
     db.session.add(family_b)
     db.session.commit()
 
-    yield
 
-    # all tables are dropped anyway
-    # db.session.delete(user)
-    # db.session.delete(admin)
+@pytest.fixture
+def login_as(client):
+    def login(identity: str) -> None:
+        assert (
+            client.post(
+                "/api/login",
+                json={"username": identity, "password": identity},
+                follow_redirects=True,
+            ).status_code
+            == 200
+        )
+
+    return login

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -22,7 +22,7 @@ class TestConfig(Config):
     )
     MINIO_ACCESS_KEY = os.getenv("TEST_MINIO_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE")
     TESTING = True
-    LOGIN_DISABLED=False
+    LOGIN_DISABLED = False
 
 
 @pytest.fixture(scope="session")

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -77,6 +77,10 @@ def test_database(client):
     db.session.add(wgs)
     db.session.flush()
 
+    pipeline_1 = Pipeline(pipeline_name="CRG", pipeline_version="1.2")
+    db.session.add(pipeline_1)
+    db.session.flush()
+
     family_a = Family(
         family_codename="A", created_by=admin.user_id, updated_by=admin.user_id
     )
@@ -139,6 +143,32 @@ def test_database(client):
     dataset_3.groups.append(group)
     sample_2.datasets.append(dataset_3)
 
+    analysis_1 = Analysis(
+        analysis_state=AnalysisState.Requested,
+        requester=admin.user_id,
+        assignee=admin.user_id,
+        updated_by=admin.user_id,
+        pipeline_id=pipeline_1.pipeline_id,
+        requested="2020-07-28",
+        started="2020-08-04",
+        updated="2020-08-04",
+    )
+    dataset_1.analyses.append(analysis_1)
+    dataset_3.analyses.append(analysis_1)
+
+    analysis_2 = Analysis(
+        analysis_state=AnalysisState.Requested,
+        requester=admin.user_id,
+        assignee=admin.user_id,
+        updated_by=admin.user_id,
+        pipeline_id=pipeline_1.pipeline_id,
+        requested="2020-07-28",
+        started="2020-08-04",
+        updated="2020-08-04",
+    )
+    dataset_2.analyses.append(analysis_2)
+    dataset_3.analyses.append(analysis_2)
+
     db.session.add(family_a)
     db.session.flush()
 
@@ -169,6 +199,19 @@ def test_database(client):
         updated_by=admin.user_id,
     )
     sample_3.datasets.append(dataset_4)
+
+    analysis_3 = Analysis(
+        analysis_state=AnalysisState.Requested,
+        requester=admin.user_id,
+        assignee=admin.user_id,
+        updated_by=admin.user_id,
+        pipeline_id=pipeline_1.pipeline_id,
+        requested="2020-07-28",
+        started="2020-08-04",
+        updated="2020-08-04",
+    )
+    dataset_1.analyses.append(analysis_3)
+    dataset_4.analyses.append(analysis_3)
 
     db.session.add(family_b)
     db.session.commit()

--- a/flask/tests/samplecsv.csv
+++ b/flask/tests/samplecsv.csv
@@ -1,0 +1,7 @@
+participant_codename,family_codename,tissue_sample_type,dataset_type,affected,participant_type,sex,month_of_birth,solved,condition,extraction_protocol,capture_kit,library_prep_method,read_length,read_type,sequencing_id,sequencing_date,sequencing_centre,batch_id
+PTP01,FAM01,Blood,WES,TRUE,Parent,Male,2016-01-01,FALSE,Control,Something,,,,PairedEnd,,,,
+PTP02,FAM01,Blood,WES,FALSE,Parent,Female,2012-01-01,FALSE,GermLine,Something,,,,SingleEnd,,,,
+PTP03,FAM01,Blood,WES,TRUE,Proband,Female,2000-06-01,FALSE,GermLine,Something,,,,PairedEnd,,,,
+BBB01,FAM02,Saliva,WES,FALSE,Parent,Male,1990-08-01,TRUE,GermLine,Something,,,,SingleEnd,,,,
+BBB02,FAM02,Saliva,WGS,TRUE,Parent,Male,1970-01-01,TRUE,GermLine,Something,,,,PairedEnd,,,,
+BBB03,FAM03,Saliva,WGS,TRUE,Proband,Female,1980-01-01,TRUE,GermLine,Something,,,,SingleEnd,,,,

--- a/flask/tests/test_analyses.py
+++ b/flask/tests/test_analyses.py
@@ -50,7 +50,6 @@ def test_get_analysis(test_database, client, login_as):
     login_as("admin")
     assert client.get("/api/analyses/4").status_code == 404
     # Test wrong permissions
-    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
     login_as("user")
     assert client.get("/api/analyses/3").status_code == 404
 
@@ -78,7 +77,6 @@ def test_delete_analysis(test_database, client, login_as):
     login_as("user")
     response = client.delete("/api/analyses/1")
     assert response.status_code == 401
-    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
     # Test with wrong id
     login_as("admin")
@@ -189,6 +187,5 @@ def test_create_analysis(test_database, client, login_as):
     assert len(analysis.datasets) == 2
     assert len(dataset_1.analyses) == 3
 
-    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
     login_as("admin")
     assert len(client.get("/api/analyses").get_json()) == 4

--- a/flask/tests/test_analyses.py
+++ b/flask/tests/test_analyses.py
@@ -78,7 +78,7 @@ def test_get_analyses(test_database, client):
 def test_delete_analysis(test_database, client):
     # Test without permission
     assert login_as(client, "user").status_code == 200
-    response = client.delete('/api/analyses/1')
+    response = client.delete("/api/analyses/1")
     assert response.status_code == 401
     assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 

--- a/flask/tests/test_analyses.py
+++ b/flask/tests/test_analyses.py
@@ -76,7 +76,7 @@ def test_get_analyses(test_database, client):
 
 
 def test_delete_analysis(test_database, client):
-    # Test without permission, will work when check_admin is implemented
+    # Test without permission
     assert login_as(client, "user").status_code == 200
     response = client.delete('/api/analyses/1')
     assert response.status_code == 401

--- a/flask/tests/test_analyses.py
+++ b/flask/tests/test_analyses.py
@@ -1,0 +1,196 @@
+import pytest
+from app import db, models
+from flask import request, jsonify, current_app as app
+from sqlalchemy.orm import joinedload
+from test_datasets import login_as
+
+# Tests
+
+# GET /api/analyses
+
+
+def test_no_analyses(test_database, client):
+    assert login_as(client, "admin").status_code == 200
+
+    response = client.get("/api/analyses?user=3")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 0
+
+
+def test_list_anaylses_admin(test_database, client):
+    assert login_as(client, "admin").status_code == 200
+
+    response = client.get("/api/analyses")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 3
+
+
+def test_list_analyses_user(test_database, client):
+    assert login_as(client, "user").status_code == 200
+
+    response = client.get("/api/analyses")
+    assert response.status_code == 200
+    # Check number of analyses
+    assert len(response.get_json()) == 2
+
+
+def test_list_analyses_user_from_admin(test_database, client):
+    # Repeat above test from admin's eyes
+    assert login_as(client, "admin").status_code == 200
+
+    response = client.get("/api/analyses?user=2")
+    assert response.status_code == 200
+    # Check number of analyses
+    assert len(response.get_json()) == 2
+
+
+# GET /api/analyses/:id
+
+
+def test_get_analyses(test_database, client):
+    # Test invalid analysis_id
+    assert login_as(client, "admin").status_code == 200
+    assert client.get("/api/analyses/4").status_code == 404
+    # Test wrong permissions
+    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
+    assert login_as(client, "user").status_code == 200
+    assert client.get("/api/analyses/3").status_code == 404
+
+    # Test and validate success based on user's permissions
+    assert login_as(client, "user").status_code == 200
+    response = client.get("/api/analyses/1")
+    assert response.status_code == 200
+    # Check number of participants in response
+    assert len(response.get_json()["datasets"]) == 1
+    assert response.get_json()["datasets"][0]["family_codename"] == "A"
+
+    # Test and validate success based on user's permissions
+    assert login_as(client, "user").status_code == 200
+    response = client.get("/api/analyses/2")
+    assert response.status_code == 200
+    # Check number of participants in response
+    assert len(response.get_json()["datasets"]) == 2
+
+
+# DELETE /api/analyses/:id
+
+
+def test_delete_analysis(test_database, client):
+    # Test without permission, will work when check_admin is implemented
+    # assert login_as(client, "user").status_code == 200
+    # response = client.delete('/api/analysis/1')
+    # assert response.status_code == 401
+    # assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
+
+    # Test with wrong id
+    assert login_as(client, "admin").status_code == 200
+    response = client.delete("/api/analyses/4")
+    assert response.status_code == 404
+
+    # Standard test
+    assert login_as(client, "admin").status_code == 200
+    assert client.delete("/api/analyses/1").status_code == 204
+    # Make sure it's gone
+    response2 = client.get("/api/analyses")
+    assert response2.status_code == 200
+    assert len(response2.get_json()) == 2
+
+
+# PATCH /api/analyses/:id
+
+
+def test_patch_participant(test_database, client):
+    assert login_as(client, "user").status_code == 200
+    # Test existence
+    assert (
+        client.patch("/api/analyses/4", json={"result_hpf_path": "blank"}).status_code
+        == 404
+    )
+    # Test permission
+    assert (
+        client.patch("/api/analyses/3", json={"result_hpf_path": "blank"}).status_code
+        == 404
+    )
+    # Test assignee does not exist
+    assert client.patch("/api/analyses/1", json={"assignee": "nope"}).status_code == 400
+    # Test enum error
+    assert (
+        client.patch(
+            "/api/analyses/1", json={"analysis_state": "not_an_enum"}
+        ).status_code
+        == 400
+    )
+    # Test success
+    response = client.patch("/api/analyses/1", json={"analysis_state": "Done"})
+    assert response.status_code == 200
+    # Make sure it updated
+    analysis = models.Analysis.query.filter(
+        models.Analysis.analysis_id == 1
+    ).one_or_none()
+    assert analysis.analysis_state == "Done"
+
+
+# POST /api/analyses
+
+
+def test_post_analyses(test_database, client):
+    assert login_as(client, "user").status_code == 200
+    # Test no pipeline id given
+    assert (
+        client.post(
+            "/api/analyses",
+            json={"datasets": "haha"},
+        ).status_code
+        == 400
+    )
+    # Test no dataset id given
+    assert (
+        client.post(
+            "/api/analyses",
+            json={"pipeline_id": "haha"},
+        ).status_code
+        == 400
+    )
+
+    # The following 2 tests have not been implemented yet, please uncomment when they have :)
+
+    # # Test invalid dataset id given
+    # assert (
+    #     client.post(
+    #         "/api/analyses", json={"datasets": "haha", "pipeline_id": 1}
+    #     ).status_code
+    #     == 400
+    # )
+
+    # # Test invalid pipeline id given
+    # assert (
+    #     client.post(
+    #         "/api/analyses", json={"datasets": [1, 2], "pipeline_id": "lol nah"}
+    #     ).status_code
+    #     == 400
+    # )
+
+    # Test success and check db
+    assert (
+        client.post(
+            "/api/analyses", json={"datasets": [1, 2], "pipeline_id": 1}
+        ).status_code
+        == 200
+    )
+    analysis = (
+        models.Analysis.query.options(joinedload(models.Analysis.datasets))
+        .filter(models.Analysis.analysis_id == 4)
+        .one_or_none()
+    )
+    dataset_1 = (
+        models.Dataset.query.options(joinedload(models.Dataset.analyses))
+        .filter(models.Dataset.dataset_id == 2)
+        .one_or_none()
+    )
+    assert analysis is not None
+    assert len(analysis.datasets) == 2
+    assert len(dataset_1.analyses) == 3
+
+    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
+    assert login_as(client, "admin").status_code == 200
+    assert len(client.get("/api/analyses").get_json()) == 4

--- a/flask/tests/test_analyses.py
+++ b/flask/tests/test_analyses.py
@@ -77,10 +77,10 @@ def test_get_analyses(test_database, client):
 
 def test_delete_analysis(test_database, client):
     # Test without permission, will work when check_admin is implemented
-    # assert login_as(client, "user").status_code == 200
-    # response = client.delete('/api/analysis/1')
-    # assert response.status_code == 401
-    # assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
+    assert login_as(client, "user").status_code == 200
+    response = client.delete('/api/analyses/1')
+    assert response.status_code == 401
+    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
     # Test with wrong id
     assert login_as(client, "admin").status_code == 200

--- a/flask/tests/test_datasets.py
+++ b/flask/tests/test_datasets.py
@@ -3,22 +3,14 @@ from app import db
 from app.models import Dataset
 
 
-def login_as(client, identity):
-    return client.post(
-        "/api/login",
-        json={"username": identity, "password": identity},
-        follow_redirects=True,
-    )
-
-
 # TODO: some tests do not precisely verify response structure
 
 
-def test_list_datasets_admin(client, test_database):
+def test_list_datasets_admin(client, test_database, login_as):
     """
     GET /api/datasets as an administrator
     """
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
 
     # Retrieve all datasets as admin
     response = client.get("/api/datasets")
@@ -41,11 +33,11 @@ def test_list_datasets_admin(client, test_database):
     assert len(response.get_json()) == 0
 
 
-def test_list_datasets_user(client, test_database):
+def test_list_datasets_user(client, test_database, login_as):
     """
     GET /api/datasets as a regular user
     """
-    assert login_as(client, "user").status_code == 200
+    login_as("user")
 
     # Retrieve all datasets I can access
     response = client.get("/api/datasets")
@@ -66,11 +58,11 @@ def test_list_datasets_user(client, test_database):
     assert len(response.get_json()) == 2
 
 
-def test_get_dataset_admin(client, test_database):
+def test_get_dataset_admin(client, test_database, login_as):
     """
     GET /api/datasets/:id as an administrator
     """
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
 
     # Retrieve all datasets as an admin
     for i in range(1, 5):
@@ -96,11 +88,11 @@ def test_get_dataset_admin(client, test_database):
     assert client.get(f"/api/datasets/4?user=2").status_code == 404
 
 
-def test_get_dataset_user(client, test_database):
+def test_get_dataset_user(client, test_database, login_as):
     """
     GET /api/datasets/:id as a regular user
     """
-    assert login_as(client, "user").status_code == 200
+    login_as("user")
 
     # Cannot assume another user's identity, query string ignored
     for query in ["", "?user=1", "?user=2"]:
@@ -110,11 +102,11 @@ def test_get_dataset_user(client, test_database):
         assert client.get(f"/api/datasets/4{query}").status_code == 404
 
 
-def test_update_dataset_admin(client, test_database):
+def test_update_dataset_admin(client, test_database, login_as):
     """
     PATCH /api/datasets/:id as an administrator
     """
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
 
     assert client.patch("/api/datasets/2").status_code == 415
     # Nonexistent
@@ -149,11 +141,11 @@ def test_update_dataset_admin(client, test_database):
             assert dataset[key] == value
 
 
-def test_update_dataset_user(client, test_database):
+def test_update_dataset_user(client, test_database, login_as):
     """
     PATCH /api/datasets/:id as a regular user
     """
-    assert login_as(client, "user").status_code == 200
+    login_as("user")
 
     assert client.patch("/api/datasets/2").status_code == 415
     # Nonexistent
@@ -174,11 +166,11 @@ def test_update_dataset_user(client, test_database):
             assert dataset[key] == value
 
 
-def test_delete_dataset_admin(client, test_database):
+def test_delete_dataset_admin(client, test_database, login_as):
     """
     DELETE /api/datasets/:id as an administrator
     """
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
 
     # Deleting a dataset with analyses
     assert client.delete("/api/datasets/1").status_code == 422
@@ -195,11 +187,11 @@ def test_delete_dataset_admin(client, test_database):
     assert client.get("/api/datasets/400").status_code == 404
 
 
-def test_delete_dataset_user(client, test_database):
+def test_delete_dataset_user(client, test_database, login_as):
     """
     DELETE /api/datasets/:id as a regular user
     """
-    assert login_as(client, "user").status_code == 200
+    login_as("user")
 
     # Regular users cannot delete
     assert client.delete("/api/datasets/1").status_code == 401
@@ -212,11 +204,11 @@ def test_delete_dataset_user(client, test_database):
     assert client.get("/api/datasets/400").status_code == 404
 
 
-def test_create_dataset(client, test_database):
+def test_create_dataset(client, test_database, login_as):
     """
     POST /api/dataset as an administrator
     """
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
 
     assert client.post("/api/datasets").status_code == 415
     invalid_requests = [

--- a/flask/tests/test_datasets.py
+++ b/flask/tests/test_datasets.py
@@ -1,0 +1,50 @@
+import pytest
+from flask import request, jsonify, current_app as app
+
+
+def login_as(client, identity):
+    return client.post(
+        "/api/login",
+        json={"username": identity, "password": identity},
+        follow_redirects=True,
+    )
+
+
+def test_list_datasets_admin(client, test_database):
+    assert login_as(client, "admin").status_code == 200
+
+    response = client.get("/api/datasets")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 4
+
+    response = client.get("/api/datasets?user=1")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 0
+
+    response = client.get("/api/datasets?user=2")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 2
+
+    response = client.get("/api/datasets?user=400")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 0
+
+
+def test_list_datasets_user(client, test_database):
+    assert login_as(client, "user").status_code == 200
+
+    response = client.get("/api/datasets")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 2
+
+    response = client.get("/api/datasets?user=1")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 2
+
+    response = client.get("/api/datasets?user=2")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 2
+
+    response = client.get("/api/datasets?user=400")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 2

--- a/flask/tests/test_datasets.py
+++ b/flask/tests/test_datasets.py
@@ -1,5 +1,6 @@
 import pytest
-from flask import request, jsonify, current_app as app
+from app import db
+from app.models import Dataset
 
 
 def login_as(client, identity):
@@ -10,33 +11,48 @@ def login_as(client, identity):
     )
 
 
+# TODO: some tests do not precisely verify response structure
+
+
 def test_list_datasets_admin(client, test_database):
+    """
+    GET /api/datasets as an administrator
+    """
     assert login_as(client, "admin").status_code == 200
 
+    # Retrieve all datasets as admin
     response = client.get("/api/datasets")
     assert response.status_code == 200
     assert len(response.get_json()) == 4
 
+    # Assume user identity belonging to no groups
     response = client.get("/api/datasets?user=1")
     assert response.status_code == 200
     assert len(response.get_json()) == 0
 
+    # Assume user identity belonging to a group with limited visibility
     response = client.get("/api/datasets?user=2")
     assert response.status_code == 200
     assert len(response.get_json()) == 2
 
+    # Assume nonexistent user identity
     response = client.get("/api/datasets?user=400")
     assert response.status_code == 200
     assert len(response.get_json()) == 0
 
 
 def test_list_datasets_user(client, test_database):
+    """
+    GET /api/datasets as a regular user
+    """
     assert login_as(client, "user").status_code == 200
 
+    # Retrieve all datasets I can access
     response = client.get("/api/datasets")
     assert response.status_code == 200
     assert len(response.get_json()) == 2
 
+    # Cannot assume another user's identity, query string ignored
     response = client.get("/api/datasets?user=1")
     assert response.status_code == 200
     assert len(response.get_json()) == 2
@@ -48,3 +64,238 @@ def test_list_datasets_user(client, test_database):
     response = client.get("/api/datasets?user=400")
     assert response.status_code == 200
     assert len(response.get_json()) == 2
+
+
+def test_get_dataset_admin(client, test_database):
+    """
+    GET /api/datasets/:id as an administrator
+    """
+    assert login_as(client, "admin").status_code == 200
+
+    # Retrieve all datasets as an admin
+    for i in range(1, 5):
+        # Retrieve as an admin
+        response = client.get(f"/api/datasets/{i}")
+        assert response.status_code == 200
+        dataset = response.get_json()
+        assert dataset["dataset_id"] == i
+        assert dataset["condition"] == "Somatic"
+        assert dataset["created_by"] == 1
+        assert dataset["updated_by"] == 1
+
+        # Assume user identity belonging to no groups
+        assert client.get(f"/api/datasets/{i}?user=1").status_code == 404
+
+        # Assume nonexistent user identity
+        assert client.get(f"/api/datasets/{i}?user=400").status_code == 404
+
+    # Assume user identity belonging to a group with limited visibility
+    assert client.get(f"/api/datasets/1?user=2").status_code == 200
+    assert client.get(f"/api/datasets/2?user=2").status_code == 404
+    assert client.get(f"/api/datasets/3?user=2").status_code == 200
+    assert client.get(f"/api/datasets/4?user=2").status_code == 404
+
+
+def test_get_dataset_user(client, test_database):
+    """
+    GET /api/datasets/:id as a regular user
+    """
+    assert login_as(client, "user").status_code == 200
+
+    # Cannot assume another user's identity, query string ignored
+    for query in ["", "?user=1", "?user=2"]:
+        assert client.get(f"/api/datasets/1{query}").status_code == 200
+        assert client.get(f"/api/datasets/2{query}").status_code == 404
+        assert client.get(f"/api/datasets/3{query}").status_code == 200
+        assert client.get(f"/api/datasets/4{query}").status_code == 404
+
+
+def test_update_dataset_admin(client, test_database):
+    """
+    PATCH /api/datasets/:id as an administrator
+    """
+    assert login_as(client, "admin").status_code == 200
+
+    assert client.patch("/api/datasets/2").status_code == 415
+    # Nonexistent
+    assert client.patch("/api/datasets/400", json={"foo": "bar"}).status_code == 404
+    # Assume user identity that does not have permission
+    assert (
+        client.patch("/api/datasets/2?user=1", json={"foo": "bar"}).status_code == 404
+    )
+
+    # Bad dataset_type
+    assert (
+        client.patch("/api/datasets/2", json={"dataset_type": "foo"}).status_code == 400
+    )
+
+    unaffected = [{"tissue_sample_id": 12}, {"analyses": []}]
+    for body in unaffected:
+        response = client.patch("/api/datasets/2", json=body)
+        assert response.status_code == 200
+        dataset = response.get_json()
+        for key, value in body.items():
+            assert key not in dataset or dataset[key] != value
+
+    changes = [
+        {"notes": "stop the count"},
+        {"dataset_type": "WES", "input_hpf_path": "/path/to/file"},
+    ]
+    for body in changes:
+        response = client.patch("/api/datasets/2", json=body)
+        assert response.status_code == 200
+        dataset = response.get_json()
+        for key, value in body.items():
+            assert dataset[key] == value
+
+
+def test_update_dataset_user(client, test_database):
+    """
+    PATCH /api/datasets/:id as a regular user
+    """
+    assert login_as(client, "user").status_code == 200
+
+    assert client.patch("/api/datasets/2").status_code == 415
+    # Nonexistent
+    assert client.patch("/api/datasets/400", json={"foo": "bar"}).status_code == 404
+    # No permission
+    assert client.patch("/api/datasets/2", json={"foo": "bar"}).status_code == 404
+
+    changes = [
+        {"notes": "stop the count"},
+        {"dataset_type": "WES", "input_hpf_path": "/path/to/file"},
+    ]
+    for body in changes:
+        response = client.patch("/api/datasets/1", json=body)
+        assert response.status_code == 200
+        dataset = response.get_json()
+        assert dataset["updated_by"] == 2
+        for key, value in body.items():
+            assert dataset[key] == value
+
+
+def test_delete_dataset_admin(client, test_database):
+    """
+    DELETE /api/datasets/:id as an administrator
+    """
+    assert login_as(client, "admin").status_code == 200
+
+    # Deleting a dataset with analyses
+    assert client.delete("/api/datasets/1").status_code == 422
+    assert client.get("/api/datasets/1").status_code == 200
+
+    # Deleting a dataset with no analyses
+    Dataset.query.get(1).analyses = []
+    db.session.commit()
+    assert client.delete("/api/datasets/1").status_code == 204
+    assert client.get("/api/datasets/1").status_code == 404
+
+    # Deleting a nonexistent dataset
+    assert client.delete("/api/datasets/400").status_code == 404
+    assert client.get("/api/datasets/400").status_code == 404
+
+
+def test_delete_dataset_user(client, test_database):
+    """
+    DELETE /api/datasets/:id as a regular user
+    """
+    assert login_as(client, "user").status_code == 200
+
+    # Regular users cannot delete
+    assert client.delete("/api/datasets/1").status_code == 401
+    assert client.get("/api/datasets/1").status_code == 200
+
+    # Regular users cannot ascertain the existence of datasets by trying to delete
+    assert client.delete("/api/datasets/2").status_code == 401
+    assert client.get("/api/datasets/2").status_code == 404
+    assert client.delete("/api/datasets/400").status_code == 401
+    assert client.get("/api/datasets/400").status_code == 404
+
+
+def test_create_dataset(client, test_database):
+    """
+    POST /api/dataset as an administrator
+    """
+    assert login_as(client, "admin").status_code == 200
+
+    assert client.post("/api/datasets").status_code == 415
+    invalid_requests = [
+        {"wait it's all 400 bad request": "always has been"},
+        # Missing fields
+        {"dataset_type": "foo"},
+        {"tissue_sample_id": "foo"},
+        {"dataset_type": "WGS", "tissue_sample_id": 1},
+        # Bad dataset_type
+        {"dataset_type": "foo", "tissue_sample_id": 1},
+    ]
+    for body in invalid_requests:
+        assert client.post("/api/datasets", json=body).status_code == 400
+
+    # Nonexistent tissue sample
+    assert (
+        client.post(
+            "/api/datasets", json={"dataset_type": "foo", "tissue_sample_id": "foo"}
+        ).status_code
+        == 404
+    )
+    assert (
+        client.post(
+            "/api/datasets", json={"dataset_type": "foo", "tissue_sample_id": 400}
+        ).status_code
+        == 404
+    )
+
+    # Successful minimal create
+    response = client.post(
+        "/api/datasets",
+        json={"dataset_type": "WGS", "tissue_sample_id": 1, "condition": "Somatic"},
+    )
+    assert response.status_code == 201
+    dataset = response.get_json()
+    assert dataset["dataset_type"] == "WGS"
+    assert dataset["tissue_sample_id"] == 1
+    assert dataset["created_by"] == 1
+    assert dataset["updated_by"] == 1
+    assert "created" in dataset and "updated" in dataset
+
+    endpoint = f"/api/datasets/{dataset['dataset_id']}"
+    assert response.location.endswith(endpoint)
+    assert client.get(endpoint).status_code == 200
+
+
+def test_unauthenticated(client, test_database):
+    """
+    Try to access all /api/datasets without signing in
+    """
+    unauthorized = [
+        client.get("/api/datasets"),
+        client.post("/api/datasets"),
+        client.get("/api/datasets/1"),
+        client.get("/api/datasets/400"),  # does not exist
+        client.patch("/api/datasets/1"),
+        client.patch("/api/datasets/400"),  # does not exist
+        client.delete("/api/datasets/1"),
+        client.delete("/api/datasets/400"),  # does not exist
+    ]
+    not_found = [
+        client.get("/api/datasets/foo"),
+        client.patch("/api/datasets/foo"),
+        client.post("/api/datasets/foo"),
+        client.put("/api/datasets/foo"),
+        client.delete("/api/datasets/foo"),
+    ]
+    method_not_allowed = [
+        client.put("/api/datasets"),
+        client.patch("/api/datasets"),
+        client.delete("/api/datasets"),
+        client.post("/api/datasets/1"),
+        client.post("/api/datasets/400"),
+        client.put("/api/datasets/1"),
+        client.put("/api/datasets/400"),
+    ]
+    for response in unauthorized:
+        assert response.status_code == 401
+    for response in not_found:
+        assert response.status_code == 404
+    for response in method_not_allowed:
+        assert response.status_code == 405

--- a/flask/tests/test_families.py
+++ b/flask/tests/test_families.py
@@ -38,6 +38,7 @@ def test_list_families_user(test_database, client):
     # Check if it is the correct family
     assert response.get_json()[0]["family_codename"] == "A"
 
+def test_list_families_user_from_admin(test_database, client):
     # Repeat above test from admin's eyes
     assert login_as(client, "admin").status_code == 200
 

--- a/flask/tests/test_families.py
+++ b/flask/tests/test_families.py
@@ -94,7 +94,7 @@ def test_get_family(test_database, client):
 def test_delete_families(test_database, client):
     # Test without permission
     assert login_as(client, "user").status_code == 200
-    response = client.delete('/api/families/1')
+    response = client.delete("/api/families/1")
     assert response.status_code == 401
     assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 

--- a/flask/tests/test_families.py
+++ b/flask/tests/test_families.py
@@ -60,7 +60,6 @@ def test_get_family(test_database, client, login_as):
     login_as("admin")
     assert client.get("/api/families/3").status_code == 404
     # Test wrong permissions
-    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
     login_as("user")
     assert client.get("/api/families/2").status_code == 404
 
@@ -94,7 +93,6 @@ def test_delete_family(test_database, client, login_as):
     login_as("user")
     response = client.delete("/api/families/1")
     assert response.status_code == 401
-    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
     # Test with wrong id
     login_as("admin")
@@ -177,6 +175,9 @@ def test_update_family(test_database, client, login_as):
 
 def test_create_family(test_database, client, login_as):
     login_as("user")
+    assert client.post("/api/families").status_code == 401
+
+    login_as("admin")
     # Test no codename given
     assert (
         client.post(
@@ -207,6 +208,6 @@ def test_create_family(test_database, client, login_as):
         models.Family.family_codename == "C"
     ).one_or_none()
     assert family is not None
-    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
+
     login_as("admin")
     assert len(client.get("/api/families").get_json()) == 3

--- a/flask/tests/test_families.py
+++ b/flask/tests/test_families.py
@@ -93,10 +93,10 @@ def test_get_family(test_database, client):
 
 def test_delete_families(test_database, client):
     # Test without permission, will work when check_admin is implemented
-    # assert login_as(client, "user").status_code == 200
-    # response = client.delete('/api/families/1')
-    # assert response.status_code == 401
-    # assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
+    assert login_as(client, "user").status_code == 200
+    response = client.delete('/api/families/1')
+    assert response.status_code == 401
+    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
     # Test with wrong id
     assert login_as(client, "admin").status_code == 200

--- a/flask/tests/test_families.py
+++ b/flask/tests/test_families.py
@@ -96,6 +96,7 @@ def test_delete_families(test_database, client):
     # assert login_as(client, "user").status_code == 200
     # response = client.delete('/api/families/1')
     # assert response.status_code == 401
+    # assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
     # Test with wrong id
     assert login_as(client, "admin").status_code == 200

--- a/flask/tests/test_families.py
+++ b/flask/tests/test_families.py
@@ -92,7 +92,7 @@ def test_get_family(test_database, client):
 
 
 def test_delete_families(test_database, client):
-    # Test without permission, will work when check_admin is implemented
+    # Test without permission
     assert login_as(client, "user").status_code == 200
     response = client.delete('/api/families/1')
     assert response.status_code == 401

--- a/flask/tests/test_families.py
+++ b/flask/tests/test_families.py
@@ -38,6 +38,7 @@ def test_list_families_user(test_database, client):
     # Check if it is the correct family
     assert response.get_json()[0]["family_codename"] == "A"
 
+
 def test_list_families_user_from_admin(test_database, client):
     # Repeat above test from admin's eyes
     assert login_as(client, "admin").status_code == 200

--- a/flask/tests/test_families.py
+++ b/flask/tests/test_families.py
@@ -1,0 +1,211 @@
+import pytest
+from app import db, models
+from flask import request, jsonify, current_app as app
+from sqlalchemy.orm import joinedload
+from test_datasets import login_as
+
+# Tests
+
+# GET /api/families
+
+
+def test_no_families(test_database, client):
+    assert login_as(client, "admin").status_code == 200
+
+    response = client.get("/api/families?user=3")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 0
+
+
+def test_list_families_admin(test_database, client):
+    assert login_as(client, "admin").status_code == 200
+
+    response = client.get("/api/families")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 2
+
+
+def test_list_families_user(test_database, client):
+    assert login_as(client, "user").status_code == 200
+
+    response = client.get("/api/families")
+    assert response.status_code == 200
+    # Check number of families
+    assert len(response.get_json()) == 1
+    # Check number of participants per family
+    assert len(response.get_json()[0]["participants"]) == 2
+
+    # Check if it is the correct family
+    assert response.get_json()[0]["family_codename"] == "A"
+
+    # Repeat above test from admin's eyes
+    assert login_as(client, "admin").status_code == 200
+
+    response = client.get("/api/families?user=2")
+    assert response.status_code == 200
+    # Check number of families
+    assert len(response.get_json()) == 1
+    # Check number of participants per family
+    assert len(response.get_json()[0]["participants"]) == 2
+
+    # Check if it is the correct family
+    assert response.get_json()[0]["family_codename"] == "A"
+
+
+# GET /api/families/:id
+
+
+def test_get_family(test_database, client):
+    # Test invalid family id
+    assert login_as(client, "admin").status_code == 200
+    assert client.get("/api/families/3").status_code == 404
+    # Test wrong permissions
+    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
+    assert login_as(client, "user").status_code == 200
+    assert client.get("/api/families/2").status_code == 404
+
+    # Test and validate success based on user's permissions
+    assert login_as(client, "user").status_code == 200
+    response = client.get("/api/families/1")
+    assert response.status_code == 200
+    # Check number of participants in response
+    assert len(response.get_json()[0]["participants"]) == 2
+    # Check number of tissue samples in response
+    assert (
+        len(response.get_json()[0]["participants"][0]["tissue_samples"]) == 1
+        and len(response.get_json()[0]["participants"][1]["tissue_samples"]) == 1
+    )
+    # Check number of datasets in response
+    assert (
+        len(response.get_json()[0]["participants"][0]["tissue_samples"][0]["datasets"])
+        == 1
+        and len(
+            response.get_json()[0]["participants"][1]["tissue_samples"][0]["datasets"]
+        )
+        == 1
+    )
+
+
+# DELETE /api/families/:id
+
+
+def test_delete_families(test_database, client):
+    # Test without permission, will work when check_admin is implemented
+    # assert login_as(client, "user").status_code == 200
+    # response = client.delete('/api/families/1')
+    # assert response.status_code == 401
+
+    # Test with wrong id
+    assert login_as(client, "admin").status_code == 200
+    response = client.delete("/api/families/3")
+    assert response.status_code == 404
+
+    # Test with participant in it
+    assert login_as(client, "admin").status_code == 200
+    response = client.delete("/api/families/2")
+    assert response.status_code == 422
+
+    # Standard test, need to clear everything below first
+    fam = (
+        models.Family.query.filter(models.Family.family_id == 1)
+        .options(
+            joinedload(models.Family.participants)
+            .joinedload(models.Participant.tissue_samples)
+            .joinedload(models.TissueSample.datasets)
+            .joinedload(models.Dataset.analyses)
+        )
+        .one_or_none()
+    )
+    for participant in fam.participants:
+        for sample in participant.tissue_samples:
+            for dataset in sample.datasets:
+                for analysis in dataset.analyses:
+                    db.session.delete(analysis)
+                db.session.delete(dataset)
+            db.session.delete(sample)
+        db.session.delete(participant)
+
+    db.session.commit()
+
+    assert login_as(client, "admin").status_code == 200
+    assert client.delete("/api/families/1").status_code == 204
+    # Make sure it's gone
+    response2 = client.get("/api/families")
+    assert response2.status_code == 200
+    assert len(response2.get_json()) == 1
+
+
+# PATCH /api/families/:id
+
+
+def test_patch_families(test_database, client):
+    assert login_as(client, "user").status_code == 200
+    # Test existence
+    assert (
+        client.patch("/api/families/4", json={"family_codename": "C"}).status_code
+        == 404
+    )
+
+    # Test permission
+    assert (
+        client.patch("/api/families/2", json={"family_codename": "C"}).status_code
+        == 404
+    )
+
+    # Test no codename error
+    assert (
+        client.patch(
+            "/api/families/2",
+            json={"Haha you thought it was a codename": "but it was I, useless json"},
+        ).status_code
+        == 400
+    )
+
+    # Test success
+    assert (
+        client.patch("/api/families/1", json={"family_codename": "C"}).status_code
+        == 200
+    )
+    # Make sure it updated
+    family = models.Family.query.filter(models.Family.family_id == 1).one_or_none()
+    assert family.family_codename == "C"
+
+
+# POST /api/families
+
+
+def test_post_families(test_database, client):
+    assert login_as(client, "user").status_code == 200
+    # Test no codename given
+    assert (
+        client.post(
+            "/api/families",
+            json={"Haha you thought it was a codename": "but it was I, useless json"},
+        ).status_code
+        == 400
+    )
+    # Test codename already in use
+    assert (
+        client.post(
+            "/api/families",
+            json={"family_codename": "A"},
+        ).status_code
+        == 422
+    )
+    # Test success and check db
+    assert (
+        client.post(
+            "/api/families",
+            json={
+                "family_codename": "C",
+            },
+        ).status_code
+        == 201
+    )
+    family = models.Family.query.filter(
+        models.Family.family_codename == "C"
+    ).one_or_none()
+    assert family is not None
+    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
+    assert login_as(client, "admin").status_code == 200
+    assert len(client.get("/api/families").get_json()) == 3

--- a/flask/tests/test_login.py
+++ b/flask/tests/test_login.py
@@ -1,6 +1,5 @@
 import pytest
 from app import db, models
-from flask import request, jsonify, current_app as app
 
 # Helper functions
 

--- a/flask/tests/test_misc.py
+++ b/flask/tests/test_misc.py
@@ -1,6 +1,5 @@
 import pytest
 from app import db, models
-from flask import request, jsonify, current_app as app
 from sqlalchemy.orm import joinedload
 
 # GET /api/pipelines
@@ -61,25 +60,25 @@ def test_post_bulk(test_database, client, login_as):
         == 422
     )
 
-    # Test enum error, THIS SOMEHOW ADDS A PARTCIPANT TO THE DB?????? so it breaks a check below???
-    # assert (
-    #     client.post(
-    #         "/api/_bulk",
-    #         json=[
-    #             {
-    #                 "family_codename": "1001",
-    #                 "participant_codename": "ANYTHING ELSE",
-    #                 "tissue_sample": "Blood",
-    #                 "tissue_sample_type": "DEFINITELY NOT AN ENUM",
-    #                 "dataset_type": "WGS",
-    #                 "condition": "GermLine",
-    #                 "gender": "Male",
-    #                 "participant_type": "Parent",
-    #             }
-    #         ],
-    #     ).status_code
-    #     == 400
-    # )
+    # Test enum error
+    assert (
+        client.post(
+            "/api/_bulk",
+            json=[
+                {
+                    "family_codename": "1001",
+                    "participant_codename": "ANYTHING ELSE",
+                    "tissue_sample": "Blood",
+                    "tissue_sample_type": "DEFINITELY NOT AN ENUM",
+                    "dataset_type": "WGS",
+                    "condition": "GermLine",
+                    "gender": "Male",
+                    "participant_type": "Parent",
+                }
+            ],
+        ).status_code
+        == 400
+    )
 
     # Test json array
     assert (

--- a/flask/tests/test_misc.py
+++ b/flask/tests/test_misc.py
@@ -1,0 +1,156 @@
+import pytest
+from app import db, models
+from flask import request, jsonify, current_app as app
+from sqlalchemy.orm import joinedload
+
+# GET /api/pipelines
+
+
+def test_get_pipelines(test_database, client, login_as):
+    # Not much to test here, if the endpoint is updated please add more tests
+    # Test success
+    login_as("admin")
+    response = client.get("/api/pipelines")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 1
+
+
+# GET /api/enums
+
+
+def test_get_enums(test_database, client, login_as):
+    # Test success
+    login_as("admin")
+    response = client.get("/api/enums")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 10
+    for enumType, enums in response.get_json().items():
+        assert enumType is not None
+
+
+# POST /api/_bulk
+
+
+def test_post_bulk(test_database, client, login_as):
+    login_as("admin")
+    # Test invalid csv
+    badsamplecsv = open("tests/badsamplecsv.csv", "r")
+    assert (
+        client.post(
+            "/api/_bulk",
+            data=badsamplecsv.read(),
+            headers={"Content-Type": "text/csv"},
+        ).status_code
+        == 400
+    )
+    # Test not json array
+    assert (
+        client.post(
+            "/api/_bulk",
+            json={
+                "family_codename": "1001",
+                "participant_codename": "06332",
+                "tissue_sample": "Blood",
+                "tissue_sample_type": "Blood",
+                "dataset_type": "WGS",
+                "condition": "GermLine",
+                "gender": "Male",
+                "participant_type": "Parent",
+            },
+        ).status_code
+        == 422
+    )
+
+    # Test enum error, THIS SOMEHOW ADDS A PARTCIPANT TO THE DB?????? so it breaks a check below???
+    # assert (
+    #     client.post(
+    #         "/api/_bulk",
+    #         json=[
+    #             {
+    #                 "family_codename": "1001",
+    #                 "participant_codename": "ANYTHING ELSE",
+    #                 "tissue_sample": "Blood",
+    #                 "tissue_sample_type": "DEFINITELY NOT AN ENUM",
+    #                 "dataset_type": "WGS",
+    #                 "condition": "GermLine",
+    #                 "gender": "Male",
+    #                 "participant_type": "Parent",
+    #             }
+    #         ],
+    #     ).status_code
+    #     == 400
+    # )
+
+    # Test json array
+    assert (
+        client.post(
+            "/api/_bulk",
+            json=[
+                {
+                    "family_codename": "1001",
+                    "participant_codename": "1411",
+                    "tissue_sample": "Blood",
+                    "tissue_sample_type": "Blood",
+                    "dataset_type": "WGS",
+                    "condition": "GermLine",
+                },
+                {
+                    "family_codename": "1001",
+                    "participant_codename": "3420",
+                    "tissue_sample": "Blood",
+                    "tissue_sample_type": "Blood",
+                    "dataset_type": "WES",
+                    "condition": "GermLine",
+                },
+            ],
+        ).status_code
+        == 200
+    )
+    # Test csv
+    goodcsv = open("tests/samplecsv.csv", "r")
+    assert (
+        client.post(
+            "/api/_bulk",
+            data=goodcsv.read(),
+            headers={"Content-Type": "text/csv"},
+        ).status_code
+        == 200
+    )
+
+    # Check db for both csv result and json array result
+
+    family = (
+        models.Family.query.options(joinedload(models.Family.participants))
+        .filter(models.Family.family_codename == "1001")
+        .one_or_none()
+    )
+    assert family is not None
+    assert len(family.participants) == 2
+
+    # part = (
+    #     models.Participant.query
+    #     .filter(models.Participant.participant_codename == "06332")
+    #     .one_or_none()
+    # )
+    # assert part.created is None
+
+    family = (
+        models.Family.query.options(joinedload(models.Family.participants))
+        .filter(models.Family.family_codename == "FAM01")
+        .one_or_none()
+    )
+    assert family is not None
+    assert len(family.participants) == 3
+
+    random_participant = (
+        models.Participant.query.options(
+            joinedload(models.Participant.tissue_samples).joinedload(
+                models.TissueSample.datasets
+            )
+        )
+        .filter(models.Participant.participant_codename == "PTP02")
+        .one_or_none()
+    )
+    assert random_participant is not None
+    assert len(random_participant.tissue_samples) == 1
+    assert len(random_participant.tissue_samples[0].datasets) == 1

--- a/flask/tests/test_participants.py
+++ b/flask/tests/test_participants.py
@@ -84,6 +84,7 @@ def test_delete_participant(test_database, client):
     # assert login_as(client, "user").status_code == 200
     # response = client.delete('/api/participants/1')
     # assert response.status_code == 401
+    # assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
     # Test with wrong id
     assert login_as(client, "admin").status_code == 200

--- a/flask/tests/test_participants.py
+++ b/flask/tests/test_participants.py
@@ -49,6 +49,7 @@ def test_list_participant_user(test_database, client):
         and diclist[0]["participant_codename"] == "002"
     )
 
+
 def test_list_participants_user_from_admin(test_database, client):
     # Repeat above test from admin's eyes
     assert login_as(client, "admin").status_code == 200

--- a/flask/tests/test_participants.py
+++ b/flask/tests/test_participants.py
@@ -1,0 +1,75 @@
+import pytest
+from app import db, models
+from flask import request, jsonify, current_app as app
+
+import json
+
+def login_as(client, identity):
+    return client.post(
+        "/api/login",
+        json={"username": identity, "password": identity},
+        follow_redirects=True,
+    )
+
+# Tests
+
+# GET /api/participants
+
+def test_no_participants(test_database, client):
+    assert login_as(client, "admin").status_code == 200
+
+    response = client.get('/api/participants?user=3')
+    assert response.status_code == 200
+    assert len(response.get_json()) == 0
+
+def test_list_participants_admin(test_database, client):
+    assert login_as(client, "admin").status_code == 200
+
+    response = client.get('/api/participants')
+    assert response.status_code == 200
+    assert len(response.get_json()) == 3
+
+def test_list_participant_user(test_database, client):
+    assert login_as(client, "user").status_code == 200
+
+    response = client.get('/api/participants')
+    assert response.status_code == 200
+    # Check number of participants
+    assert len(response.get_json()) == 2
+    # Check number of tissue samples per participant
+    assert len(response.get_json()[0]["tissue_samples"]) == 1
+    assert len(response.get_json()[1]["tissue_samples"]) == 1
+    # Check number of datasets per tissue sample in participant
+    assert len(response.get_json()[0]["tissue_samples"][0]["datasets"]) == 1
+    assert len(response.get_json()[1]["tissue_samples"][0]["datasets"]) == 1
+
+    # Check if they are the right participants
+    diclist = response.get_json()
+    assert (diclist[0]["participant_codename"] == "001" and diclist[1]["participant_codename"] == "002") or (diclist[1]["participant_codename"] == "001" and diclist[0]["participant_codename"] == "002")
+
+
+    # Repeat above test from admin's eyes
+    assert login_as(client, "admin").status_code == 200
+
+    response = client.get('/api/participants?user=2')
+    assert response.status_code == 200
+    # Check number of participants
+    assert len(response.get_json()) == 2
+    # Check number of tissue samples per participant
+    assert len(response.get_json()[0]["tissue_samples"]) == 1
+    assert len(response.get_json()[1]["tissue_samples"]) == 1
+    # Check number of datasets per tissue sample in participant
+    assert len(response.get_json()[0]["tissue_samples"][0]["datasets"]) == 1
+    assert len(response.get_json()[1]["tissue_samples"][0]["datasets"]) == 1
+
+    # Check if they are the right participants
+    diclist = response.get_json()
+    assert (diclist[0]["participant_codename"] == "001" and diclist[1]["participant_codename"] == "002") or (diclist[1]["participant_codename"] == "001" and diclist[0]["participant_codename"] == "002")
+
+
+
+# DELETE /api/participants/:id
+
+
+
+# PATCH /api/participants/:id

--- a/flask/tests/test_participants.py
+++ b/flask/tests/test_participants.py
@@ -49,6 +49,7 @@ def test_list_participant_user(test_database, client):
         and diclist[0]["participant_codename"] == "002"
     )
 
+def test_list_participants_user_from_admin(test_database, client):
     # Repeat above test from admin's eyes
     assert login_as(client, "admin").status_code == 200
 

--- a/flask/tests/test_participants.py
+++ b/flask/tests/test_participants.py
@@ -81,10 +81,10 @@ def test_list_participants_user_from_admin(test_database, client):
 
 def test_delete_participant(test_database, client):
     # Test without permission, will work when check_admin is implemented
-    # assert login_as(client, "user").status_code == 200
-    # response = client.delete('/api/participants/1')
-    # assert response.status_code == 401
-    # assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
+    assert login_as(client, "user").status_code == 200
+    response = client.delete('/api/participants/1')
+    assert response.status_code == 401
+    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
     # Test with wrong id
     assert login_as(client, "admin").status_code == 200

--- a/flask/tests/test_participants.py
+++ b/flask/tests/test_participants.py
@@ -82,7 +82,7 @@ def test_list_participants_user_from_admin(test_database, client):
 def test_delete_participant(test_database, client):
     # Test without permission
     assert login_as(client, "user").status_code == 200
-    response = client.delete('/api/participants/1')
+    response = client.delete("/api/participants/1")
     assert response.status_code == 401
     assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 

--- a/flask/tests/test_participants.py
+++ b/flask/tests/test_participants.py
@@ -1,32 +1,30 @@
 import pytest
 from app import db, models
-from flask import request, jsonify, current_app as app
 from sqlalchemy.orm import joinedload
-from test_datasets import login_as
 
 # Tests
 
 # GET /api/participants
 
 
-def test_no_participants(test_database, client):
-    assert login_as(client, "admin").status_code == 200
+def test_no_participants(test_database, client, login_as):
+    login_as("admin")
 
     response = client.get("/api/participants?user=3")
     assert response.status_code == 200
     assert len(response.get_json()) == 0
 
 
-def test_list_participants_admin(test_database, client):
-    assert login_as(client, "admin").status_code == 200
+def test_list_participants_admin(test_database, client, login_as):
+    login_as("admin")
 
     response = client.get("/api/participants")
     assert response.status_code == 200
     assert len(response.get_json()) == 3
 
 
-def test_list_participant_user(test_database, client):
-    assert login_as(client, "user").status_code == 200
+def test_list_participants_user(test_database, client, login_as):
+    login_as("user")
 
     response = client.get("/api/participants")
     assert response.status_code == 200
@@ -50,9 +48,9 @@ def test_list_participant_user(test_database, client):
     )
 
 
-def test_list_participants_user_from_admin(test_database, client):
+def test_list_participants_user_from_admin(test_database, client, login_as):
     # Repeat above test from admin's eyes
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
 
     response = client.get("/api/participants?user=2")
     assert response.status_code == 200
@@ -79,20 +77,20 @@ def test_list_participants_user_from_admin(test_database, client):
 # DELETE /api/participants/:id
 
 
-def test_delete_participant(test_database, client):
+def test_delete_participant(test_database, client, login_as):
     # Test without permission
-    assert login_as(client, "user").status_code == 200
+    login_as("user")
     response = client.delete("/api/participants/1")
     assert response.status_code == 401
     assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
     # Test with wrong id
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
     response = client.delete("/api/participants/4")
     assert response.status_code == 404
 
     # Test with tissue sample in it
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
     response = client.delete("/api/participants/1")
     assert response.status_code == 422
 
@@ -116,7 +114,7 @@ def test_delete_participant(test_database, client):
 
     db.session.commit()
 
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
     assert client.delete("/api/participants/1").status_code == 204
     # Make sure it's gone
     response2 = client.get("/api/participants")
@@ -127,8 +125,8 @@ def test_delete_participant(test_database, client):
 # PATCH /api/participants/:id
 
 
-def test_patch_participant(test_database, client):
-    assert login_as(client, "user").status_code == 200
+def test_update_participant(test_database, client, login_as):
+    login_as("user")
     # Test existence
     assert (
         client.patch("/api/participants/4", json={"notes": "blank"}).status_code == 404
@@ -157,8 +155,8 @@ def test_patch_participant(test_database, client):
 # POST /api/participants
 
 
-def test_post_participants(test_database, client):
-    assert login_as(client, "user").status_code == 200
+def test_create_participant(test_database, client, login_as):
+    login_as("user")
     # Test family does not exist
     assert client.post("/api/participants", json={"family_id": "3"}).status_code == 404
     # Test if participant in family already exists

--- a/flask/tests/test_participants.py
+++ b/flask/tests/test_participants.py
@@ -80,7 +80,7 @@ def test_list_participants_user_from_admin(test_database, client):
 
 
 def test_delete_participant(test_database, client):
-    # Test without permission, will work when check_admin is implemented
+    # Test without permission
     assert login_as(client, "user").status_code == 200
     response = client.delete('/api/participants/1')
     assert response.status_code == 401

--- a/flask/tests/test_participants.py
+++ b/flask/tests/test_participants.py
@@ -4,8 +4,6 @@ from flask import request, jsonify, current_app as app
 from sqlalchemy.orm import joinedload
 from test_datasets import login_as
 
-import json
-
 # Tests
 
 # GET /api/participants

--- a/flask/tests/test_participants.py
+++ b/flask/tests/test_participants.py
@@ -82,7 +82,6 @@ def test_delete_participant(test_database, client, login_as):
     login_as("user")
     response = client.delete("/api/participants/1")
     assert response.status_code == 401
-    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
     # Test with wrong id
     login_as("admin")
@@ -157,6 +156,9 @@ def test_update_participant(test_database, client, login_as):
 
 def test_create_participant(test_database, client, login_as):
     login_as("user")
+    assert client.post("/api/participants").status_code == 401
+
+    login_as("admin")
     # Test family does not exist
     assert client.post("/api/participants", json={"family_id": "3"}).status_code == 404
     # Test if participant in family already exists
@@ -197,4 +199,4 @@ def test_create_participant(test_database, client, login_as):
         models.Participant.participant_codename == "004",
     ).one_or_none()
     assert participant.notes == "nothing"
-    assert participant.created_by == 2
+    assert participant.created_by == 1

--- a/flask/tests/test_samples.py
+++ b/flask/tests/test_samples.py
@@ -2,23 +2,22 @@ import pytest
 from app import db, models
 from flask import request, jsonify, current_app as app
 from sqlalchemy.orm import joinedload
-from test_datasets import login_as
 
 
 # GET /api/tissue_samples/:id
 
 
-def test_get_tissue_samples(test_database, client):
+def test_get_tissue_samples(test_database, client, login_as):
     # Test invalid sample id
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
     assert client.get("/api/tissue_samples/4").status_code == 404
     # Test wrong permissions
     assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
-    assert login_as(client, "user").status_code == 200
+    login_as("user")
     assert client.get("/api/tissue_samples/3").status_code == 404
 
     # Test and validate success based on user's permissions
-    assert login_as(client, "user").status_code == 200
+    login_as("user")
     response = client.get("/api/tissue_samples/1")
     assert response.status_code == 200
     # Check number of datasets in response
@@ -28,20 +27,20 @@ def test_get_tissue_samples(test_database, client):
 # DELETE /api/tissue_samples/:id
 
 
-def test_delete_tissue_samples(test_database, client):
+def test_delete_tissue_samples(test_database, client, login_as):
     # Test without permission
-    assert login_as(client, "user").status_code == 200
+    login_as("user")
     response = client.delete("/api/tissue_samples/1")
     assert response.status_code == 401
     assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
     # Test with wrong id
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
     response = client.delete("/api/tissue_samples/4")
     assert response.status_code == 404
 
     # Test with dataset in it
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
     response = client.delete("/api/tissue_samples/1")
     assert response.status_code == 422
 
@@ -60,7 +59,7 @@ def test_delete_tissue_samples(test_database, client):
 
     db.session.commit()
 
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
     assert client.delete("/api/tissue_samples/1").status_code == 204
     # Make sure it's gone
     sample = models.TissueSample.query.filter(
@@ -72,14 +71,14 @@ def test_delete_tissue_samples(test_database, client):
 # POST /api/tissue_samples
 
 
-def test_post_tissue_samples(test_database, client):
+def test_post_tissue_samples(test_database, client, login_as):
     # Test without permission
-    assert login_as(client, "user").status_code == 200
+    login_as("user")
     response = client.post("/api/tissue_samples")
     assert response.status_code == 401
     assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
-    assert login_as(client, "admin").status_code == 200
+    login_as("admin")
     # Test no tissue_sample_type given
     assert (
         client.post(

--- a/flask/tests/test_samples.py
+++ b/flask/tests/test_samples.py
@@ -1,18 +1,16 @@
 import pytest
 from app import db, models
-from flask import request, jsonify, current_app as app
 from sqlalchemy.orm import joinedload
 
 
 # GET /api/tissue_samples/:id
 
 
-def test_get_tissue_samples(test_database, client, login_as):
+def test_get_tissue_sample(test_database, client, login_as):
     # Test invalid sample id
     login_as("admin")
     assert client.get("/api/tissue_samples/4").status_code == 404
     # Test wrong permissions
-    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
     login_as("user")
     assert client.get("/api/tissue_samples/3").status_code == 404
 
@@ -27,12 +25,11 @@ def test_get_tissue_samples(test_database, client, login_as):
 # DELETE /api/tissue_samples/:id
 
 
-def test_delete_tissue_samples(test_database, client, login_as):
+def test_delete_tissue_sample(test_database, client, login_as):
     # Test without permission
     login_as("user")
     response = client.delete("/api/tissue_samples/1")
     assert response.status_code == 401
-    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
     # Test with wrong id
     login_as("admin")
@@ -71,12 +68,11 @@ def test_delete_tissue_samples(test_database, client, login_as):
 # POST /api/tissue_samples
 
 
-def test_post_tissue_samples(test_database, client, login_as):
+def test_create_tissue_sample(test_database, client, login_as):
     # Test without permission
     login_as("user")
     response = client.post("/api/tissue_samples")
     assert response.status_code == 401
-    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
 
     login_as("admin")
     # Test no tissue_sample_type given

--- a/flask/tests/test_samples.py
+++ b/flask/tests/test_samples.py
@@ -1,0 +1,143 @@
+import pytest
+from app import db, models
+from flask import request, jsonify, current_app as app
+from sqlalchemy.orm import joinedload
+from test_datasets import login_as
+
+
+# GET /api/tissue_samples/:id
+
+
+def test_get_tissue_samples(test_database, client):
+    # Test invalid sample id
+    assert login_as(client, "admin").status_code == 200
+    assert client.get("/api/tissue_samples/4").status_code == 404
+    # Test wrong permissions
+    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
+    assert login_as(client, "user").status_code == 200
+    assert client.get("/api/tissue_samples/3").status_code == 404
+
+    # Test and validate success based on user's permissions
+    assert login_as(client, "user").status_code == 200
+    response = client.get("/api/tissue_samples/1")
+    assert response.status_code == 200
+    # Check number of datasets in response
+    assert len(response.get_json()["datasets"]) == 1
+
+
+# DELETE /api/tissue_samples/:id
+
+
+def test_delete_tissue_samples(test_database, client):
+    # Test without permission
+    assert login_as(client, "user").status_code == 200
+    response = client.delete("/api/tissue_samples/1")
+    assert response.status_code == 401
+    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
+
+    # Test with wrong id
+    assert login_as(client, "admin").status_code == 200
+    response = client.delete("/api/tissue_samples/4")
+    assert response.status_code == 404
+
+    # Test with dataset in it
+    assert login_as(client, "admin").status_code == 200
+    response = client.delete("/api/tissue_samples/1")
+    assert response.status_code == 422
+
+    # Standard test, need to clear everything below first
+    sample = (
+        models.TissueSample.query.filter(models.TissueSample.tissue_sample_id == 1)
+        .options(
+            joinedload(models.TissueSample.datasets).joinedload(models.Dataset.analyses)
+        )
+        .one_or_none()
+    )
+    for dataset in sample.datasets:
+        for analysis in dataset.analyses:
+            db.session.delete(analysis)
+        db.session.delete(dataset)
+
+    db.session.commit()
+
+    assert login_as(client, "admin").status_code == 200
+    assert client.delete("/api/tissue_samples/1").status_code == 204
+    # Make sure it's gone
+    sample = models.TissueSample.query.filter(
+        models.TissueSample.tissue_sample_id == 1
+    ).one_or_none()
+    assert sample is None
+
+
+# POST /api/tissue_samples
+
+
+def test_post_tissue_samples(test_database, client):
+    # Test without permission
+    assert login_as(client, "user").status_code == 200
+    response = client.post("/api/tissue_samples")
+    assert response.status_code == 401
+    assert client.post("/api/logout", json={"useless": "why"}).status_code == 204
+
+    assert login_as(client, "admin").status_code == 200
+    # Test no tissue_sample_type given
+    assert (
+        client.post(
+            "/api/tissue_samples",
+            json={"participant_id": "1"},
+        ).status_code
+        == 400
+    )
+    # Test no participant_id given
+    assert (
+        client.post(
+            "/api/tissue_samples",
+            json={"tissue_sample_type": "Blood"},
+        ).status_code
+        == 400
+    )
+    # Test invalid participant id given
+    assert (
+        client.post(
+            "/api/tissue_samples",
+            json={
+                "tissue_sample_type": "Blood",
+                "participant_id": "nope",
+            },
+        ).status_code
+        == 404
+    )
+    # Test enum error
+    assert (
+        client.post(
+            "/api/tissue_samples",
+            json={
+                "tissue_sample_type": "not even close to an enum",
+                "participant_id": "1",
+            },
+        ).status_code
+        == 400
+    )
+
+    # Test success and check db
+    assert (
+        client.post(
+            "/api/tissue_samples",
+            json={
+                "tissue_sample_type": "Blood",
+                "participant_id": "1",
+                "notes": "nothing really",
+            },
+        ).status_code
+        == 201
+    )
+    sample = (
+        models.TissueSample.query.options(joinedload(models.TissueSample.datasets))
+        .filter(models.TissueSample.notes == "nothing really")
+        .one_or_none()
+    )
+    assert sample is not None
+    assert sample.participant_id == 1
+    assert len(sample.datasets) == 0
+    assert sample.created_by == 1
+    assert sample.updated_by == 1


### PR DESCRIPTION
Implement check_admin decorator
Add Config.SQLALCHEMY_LOG to disable SQL query logs in unit tests

Closes #165