### PR TITLE
React: Fix notes changing table row height

### DIFF
--- a/react/src/pages/analysis/Analyses.tsx
+++ b/react/src/pages/analysis/Analyses.tsx
@@ -19,6 +19,7 @@ import AnalysisInfoDialog from "../utils/components/AnalysisInfoDialog";
 import CancelAnalysisDialog from "./CancelAnalysisDialog";
 import AddAnalysisAlert from "./AddAnalysisAlert";
 import SetAssigneeDialog from "./SetAssigneeDialog";
+import Note from "../utils/components/Note";
 
 const useStyles = makeStyles(theme => ({
     appBarSpacer: theme.mixins.toolbar,
@@ -351,7 +352,7 @@ export default function Analyses() {
                             title: "Notes",
                             field: "notes",
                             type: "string",
-                            width: "30%",
+                            render: rowData => <Note>{rowData.notes}</Note>,
                             editComponent: props => (
                                 <TextField
                                     multiline

--- a/react/src/pages/datasets/DatasetTable.tsx
+++ b/react/src/pages/datasets/DatasetTable.tsx
@@ -9,6 +9,7 @@ import { toKeyValue, formatDateString } from "../utils/functions";
 import { KeyValue, Dataset, Pipeline } from "../utils/typings";
 import AnalysisRunnerDialog from "./AnalysisRunnerDialog";
 import DatasetInfoDialog from "./DatasetInfoDialog";
+import Note from "../utils/components/Note";
 
 const useStyles = makeStyles(theme => ({
     chip: {
@@ -137,6 +138,7 @@ export default function DatasetTable() {
                         title: "Notes",
                         field: "notes",
                         grouping: false,
+                        render: rowData => <Note>{rowData.notes}</Note>,
                         editComponent: props => (
                             <TextField
                                 multiline

--- a/react/src/pages/participants/ParticipantTable.tsx
+++ b/react/src/pages/participants/ParticipantTable.tsx
@@ -8,6 +8,7 @@ import { countArray, toKeyValue } from "../utils/functions";
 import { KeyValue, Participant } from "../utils/typings";
 import DatasetTypes from "./DatasetTypes";
 import ParticipantInfoDialog from "./ParticipantInfoDialog";
+import Note from "../utils/components/Note";
 
 const useStyles = makeStyles(theme => ({
     chip: {
@@ -121,6 +122,7 @@ export default function ParticipantTable() {
                         title: "Notes",
                         field: "notes",
                         grouping: false,
+                        render: rowData => <Note>{rowData.notes}</Note>,
                         editComponent: props => (
                             <TextField
                                 multiline

--- a/react/src/pages/utils/components/Note.tsx
+++ b/react/src/pages/utils/components/Note.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core";
+
+const useStyles = makeStyles(theme => ({
+    notes: {
+        // TODO: Find a better way to set maxWidth using container width
+        maxWidth: "16em",
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        "&:hover": {
+            whiteSpace: "normal",
+            textOverflow: "default",
+        },
+    },
+}));
+
+/**
+ * A style wrapper for strings of text that are really long.
+ */
+export default function Note(props: { children: React.ReactNode }) {
+    const classes = useStyles();
+
+    return <div className={classes.notes}>{props.children}</div>;
+}

--- a/react/src/pages/utils/components/Note.tsx
+++ b/react/src/pages/utils/components/Note.tsx
@@ -1,17 +1,22 @@
-import React from "react";
-import { makeStyles } from "@material-ui/core";
+import React, { useState } from "react";
+import { makeStyles, Popover, Typography } from "@material-ui/core";
 
 const useStyles = makeStyles(theme => ({
     notes: {
-        // TODO: Find a better way to set maxWidth using container width
+        minWidth: "inherit",
         maxWidth: "16em",
         whiteSpace: "nowrap",
         overflow: "hidden",
         textOverflow: "ellipsis",
-        "&:hover": {
-            whiteSpace: "normal",
-            textOverflow: "default",
-        },
+        cursor: "pointer",
+        textDecoration: "underline dashed",
+        textDecorationColor: theme.palette.text.hint,
+    },
+    typography: {
+        padding: theme.spacing(1),
+    },
+    paper: {
+        maxWidth: theme.breakpoints.values.sm,
     },
 }));
 
@@ -20,6 +25,21 @@ const useStyles = makeStyles(theme => ({
  */
 export default function Note(props: { children: React.ReactNode }) {
     const classes = useStyles();
+    const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
 
-    return <div className={classes.notes}>{props.children}</div>;
+    return (
+        <>
+            <div className={classes.notes} onClick={event => setAnchorEl(event.currentTarget)}>
+                {props.children}
+            </div>
+            <Popover
+                open={!!anchorEl}
+                anchorEl={anchorEl}
+                onClose={() => setAnchorEl(null)}
+                PaperProps={{ className: classes.paper }}
+            >
+                <Typography className={classes.typography}>{props.children}</Typography>
+            </Popover>
+        </>
+    );
 }


### PR DESCRIPTION
Closes #231 
The component handles overflowing text in `notes` columns, and expands on mouse hover to show the entire entry.