### PR TITLE
Flask: Groups endpoints

### DIFF
--- a/flask/app/__init__.py
+++ b/flask/app/__init__.py
@@ -40,5 +40,6 @@ def create_app(config):
         from . import families
         from . import datasets
         from . import participants
+        from . import groups
 
         return app

--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -1,0 +1,64 @@
+from flask import abort, jsonify, request, Response, current_app as app
+from flask_login import login_user, logout_user, current_user, login_required
+from app import db, login, models
+from sqlalchemy.orm import contains_eager, joinedload
+from .routes import check_admin, transaction_or_abort
+
+
+@app.route("/api/groups", methods=["GET"])
+@login_required
+def list_groups():
+    if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
+        user_id = request.args.get("user")
+    else:
+        user_id = current_user.user_id
+
+    if user_id:
+        groups = (
+            models.Group.query.join(models.Group.users)
+            .filter(models.User.user_id == user_id)
+            .all()
+        )
+    else:
+        groups = models.Group.query.all()
+
+    return jsonify(
+        [
+            {"group_code": group.group_code, "group_name": group.group_name}
+            for group in groups
+        ]
+    )
+
+
+@app.route("/api/groups/<string:group_code>", methods=["GET"])
+@login_required
+def get_group(group_code):
+    if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
+        user_id = request.args.get("user")
+    else:
+        user_id = current_user.user_id
+
+    if user_id:
+        group = (
+            models.Group.query.filter(models.Group.group_code == group_code)
+            .join(models.Group.users)
+            .filter(models.User.user_id == user_id)
+            .one_or_none()
+        )
+    else:
+        group = models.Group.query.filter(
+            models.Group.group_code == group_code
+        ).one_or_none()
+
+    if group is None:
+        return "Forbidden", 403
+
+    return jsonify(
+        {
+            "group_code": group.group_code,
+            "group_name": group.group_name,
+            "users": [
+                user.username for user in group.users if user.deactivated == False
+            ],
+        }
+    )

--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -4,7 +4,6 @@ from app import db, login, models
 from sqlalchemy.orm import contains_eager, joinedload
 from .routes import check_admin, transaction_or_abort, mixin
 from minio import Minio
-from os import environ
 from .madmin import MinioAdmin, readwrite_buckets_policy
 
 
@@ -88,9 +87,9 @@ def update_group(group_code):
             group.group_name = request.json["group_name"]
 
     minioAdmin = MinioAdmin(
-        endpoint=environ["MINIO_ENDPOINT"],
-        access_key=environ["MINIO_ACCESS_KEY"],
-        secret_key=environ["MINIO_SECRET_KEY"],
+        endpoint=app.config["MINIO_ENDPOINT"],
+        access_key=app.config["MINIO_ACCESS_KEY"],
+        secret_key=app.config["MINIO_SECRET_KEY"],
     )
 
     # Check if a user to be added doesn't exist, 404
@@ -160,16 +159,16 @@ def create_group():
             group_obj.users.append(user)
 
     minioClient = Minio(
-        environ["MINIO_ENDPOINT"],
-        access_key=environ["MINIO_ACCESS_KEY"],
-        secret_key=environ["MINIO_SECRET_KEY"],
+        app.config["MINIO_ENDPOINT"],
+        access_key=app.config["MINIO_ACCESS_KEY"],
+        secret_key=app.config["MINIO_SECRET_KEY"],
         secure=False,
     )
 
     minioAdmin = MinioAdmin(
-        endpoint=environ["MINIO_ENDPOINT"],
-        access_key=environ["MINIO_ACCESS_KEY"],
-        secret_key=environ["MINIO_SECRET_KEY"],
+        endpoint=app.config["MINIO_ENDPOINT"],
+        access_key=app.config["MINIO_ACCESS_KEY"],
+        secret_key=app.config["MINIO_SECRET_KEY"],
     )
 
     # Create minio bucket via mc, 422 if it already exists
@@ -205,9 +204,9 @@ def delete_group(group_code):
     group = models.Group.query.filter_by(group_code=group_code).first_or_404()
 
     minioAdmin = MinioAdmin(
-        endpoint=environ["MINIO_ENDPOINT"],
-        access_key=environ["MINIO_ACCESS_KEY"],
-        secret_key=environ["MINIO_SECRET_KEY"],
+        endpoint=app.config["MINIO_ENDPOINT"],
+        access_key=app.config["MINIO_ACCESS_KEY"],
+        secret_key=app.config["MINIO_SECRET_KEY"],
     )
 
     # Check group users in db

--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -3,9 +3,10 @@ from flask_login import login_user, logout_user, current_user, login_required
 from app import db, login, models
 from sqlalchemy.orm import contains_eager, joinedload
 from .routes import check_admin, transaction_or_abort, mixin
-from minio import  Minio
+from minio import Minio
 from os import environ
 from .madmin import MinioAdmin, readwrite_buckets_policy
+
 
 @app.route("/api/groups", methods=["GET"])
 @login_required
@@ -162,7 +163,7 @@ def create_group():
         environ["MINIO_ENDPOINT"],
         access_key=environ["MINIO_ACCESS_KEY"],
         secret_key=environ["MINIO_SECRET_KEY"],
-        secure=False
+        secure=False,
     )
 
     minioAdmin = MinioAdmin(

--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -103,10 +103,11 @@ def update_group(group_code):
                 return "Invalid username provided", 404
 
             # Clear users from db and minio group
-            group.users[:] = []
-            group_info = minioAdmin.get_group(group_code)
-            for old_user in group_info["members"]:
-                minioAdmin.group_remove(group_code, old_user)
+            if len(group.users) != 0:
+                group_info = minioAdmin.get_group(group_code)
+                for old_user in group_info["members"]:
+                    minioAdmin.group_remove(group_code, old_user)
+                group.users[:] = []
 
             for user in users:
                 # Add to db groups
@@ -122,3 +123,104 @@ def update_group(group_code):
     except:
         db.session.rollback()
         return "Server error", 500
+
+
+@app.route("/api/groups", methods=["POST"])
+@login_required
+@check_admin
+def create_group():
+    if not request.json:
+        return "Request body must be JSON", 400
+
+    group_name = request.json.get("group_name")
+    group_code = request.json.get("group_code")
+
+    if not group_name:
+        return "A group display name must be provided", 400
+    if not group_code:
+        return "A group codename must be provided", 400
+
+    if models.Group.query.filter(
+        (models.Group.group_code == group_code)
+        | (models.Group.group_name == group_name)
+    ).value("group_id"):
+        return "Group already exists", 422
+
+    group_obj = models.Group(group_code=group_code, group_name=group_name)
+
+    # Add users to the db if they were given
+    if request.json.get("users"):
+        users = models.User.query.filter(
+            models.User.username.in_(request.json["users"])
+        ).all()
+        # Make sure all users are valid
+        if len(users) != len(request.json["users"]):
+            return "Invalid username provided", 404
+        for user in users:
+            group_obj.users.append(user)
+
+    minioClient = Minio(
+        environ["MINIO_ENDPOINT"],
+        access_key=environ["MINIO_ACCESS_KEY"],
+        secret_key=environ["MINIO_SECRET_KEY"],
+        secure=False
+    )
+
+    minioAdmin = MinioAdmin(
+        endpoint=environ["MINIO_ENDPOINT"],
+        access_key=environ["MINIO_ACCESS_KEY"],
+        secret_key=environ["MINIO_SECRET_KEY"],
+    )
+
+    # Create minio bucket via mc, 422 if it already exists
+    if minioClient.bucket_exists(group_code):
+        return "Minio bucket already exists", 422
+
+    minioClient.make_bucket(group_code)
+    # Make corresponding policy
+    policy = readwrite_buckets_policy(group_code)
+    minioAdmin.add_policy(group_code, policy)
+
+    # Add users to minio group if applicable, creating group as well
+    if request.json.get("users"):
+        for user in users:
+            minioAdmin.group_add(group_code, user.minio_access_key)
+
+        # Set group access policy to the bucket by the same name
+        minioAdmin.set_policy(group_code, group=group_code)
+
+    db.session.add(group_obj)
+    transaction_or_abort(db.session.commit)
+
+    location_header = "/api/groups/{}".format(group_obj.group_code)
+
+    return request.json, 201, {"location": location_header}
+
+
+# @app.route("/api/groups/<string:group_code>", methods=["DELETE"])
+# @login_required
+# @check_admin
+# def delete_group(group_code):
+
+#     group = models.Group.query.filter_by(group_code=group_code).first_or_404()
+
+#     minioAdmin = MinioAdmin(
+#         endpoint=environ["MINIO_ENDPOINT"],
+#         access_key=environ["MINIO_ACCESS_KEY"],
+#         secret_key=environ["MINIO_SECRET_KEY"],
+#     )
+
+
+
+#     # Make sure db group and minio group are empty
+#     if len(group.users) == 0 and :
+#         try:
+#             # Try deleting minio group as well
+#             group.delete()
+#             db.session.commit()
+#             return "Deletion successful", 204
+#         except:
+#             db.session.rollback()
+#             return "Deletion of entity failed!", 422
+#     else:
+#         return "Group has users, cannot delete!", 422

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -64,11 +64,13 @@ def test_database(client):
 
     admin = User(username="admin", email="noreply@sickkids.ca", is_admin=True)
     admin.set_password("admin")
+    admin.minio_access_key="admin"
     db.session.add(admin)
     db.session.flush()
 
     user = User(username="user", email="test@sickkids.ca")
     user.set_password("user")
+    user.minio_access_key="user"
     user.groups.append(group)
     db.session.add(user)
     db.session.flush()

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -64,13 +64,13 @@ def test_database(client):
 
     admin = User(username="admin", email="noreply@sickkids.ca", is_admin=True)
     admin.set_password("admin")
-    admin.minio_access_key="admin"
+    admin.minio_access_key = "admin"
     db.session.add(admin)
     db.session.flush()
 
     user = User(username="user", email="test@sickkids.ca")
     user.set_password("user")
-    user.minio_access_key="user"
+    user.minio_access_key = "user"
     user.groups.append(group)
     db.session.add(user)
     db.session.flush()

--- a/flask/tests/test_groups.py
+++ b/flask/tests/test_groups.py
@@ -211,6 +211,7 @@ def test_create_group(test_database, client, login_as, minioAdmin):
     )
     group = models.Group.query.filter(models.Group.group_code == "code").one_or_none()
     assert group is not None
+    assert len(group.users) == 0
     assert len(minioAdmin.list_policies()) == 6
     minioClient = Minio(
         TestConfig.MINIO_ENDPOINT,
@@ -239,6 +240,7 @@ def test_create_group(test_database, client, login_as, minioAdmin):
     )
     group = models.Group.query.filter(models.Group.group_code == "code2").one_or_none()
     assert group is not None
+    assert len(group.users) == 1
     assert len(minioAdmin.list_policies()) == 6
     assert len(minioAdmin.get_group("code2")["members"]) == 1
     minioClient = Minio(

--- a/flask/tests/test_groups.py
+++ b/flask/tests/test_groups.py
@@ -200,6 +200,14 @@ def test_create_group(test_database, client, login_as, minioAdmin):
         ).status_code
         == 422
     )
+    # Test invlaid bucket name
+    assert (
+        client.post(
+            "/api/groups",
+            json={"group_code": "sk", "group_name": "Invalid s3 bucket name"},
+        ).status_code
+        == 422
+    )
 
     # Test success with no users and check db and minio
     assert (

--- a/flask/tests/test_groups.py
+++ b/flask/tests/test_groups.py
@@ -110,6 +110,7 @@ def test_delete_group(test_database, client, login_as):
     assert group == None
     assert len(minioAdmin.list_groups()) == 0
 
+
 """
 
 

--- a/flask/tests/test_groups.py
+++ b/flask/tests/test_groups.py
@@ -1,0 +1,193 @@
+import pytest
+from app import db, models
+from sqlalchemy.orm import joinedload
+from conftest import TestConfig
+from app.madmin import MinioAdmin
+
+# Tests
+
+# GET /api/groups
+
+
+def test_no_groups(test_database, client, login_as):
+    login_as("admin")
+
+    response = client.get("/api/groups?user=3")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 0
+
+
+def test_list_groups_admin(test_database, client, login_as):
+    login_as("admin")
+
+    response = client.get("/api/groups")
+    assert response.status_code == 200
+    assert len(response.get_json()) == 1
+
+
+def test_list_groups_user(test_database, client, login_as):
+    login_as("user")
+
+    response = client.get("/api/groups")
+    assert response.status_code == 200
+    # Check number of groups
+    assert len(response.get_json()) == 1
+
+
+def test_list_groups_user_from_admin(test_database, client, login_as):
+    # Repeat above test from admin's eyes
+    login_as("admin")
+
+    response = client.get("/api/groups?user=2")
+    assert response.status_code == 200
+    # Check number of groups
+    assert len(response.get_json()) == 1
+
+
+# GET /api/groups/:id
+
+
+def test_get_group(test_database, client, login_as):
+    # Test invalid group_code
+    login_as("admin")
+    assert client.get("/api/groups/hahah").status_code == 403
+
+    group_2 = models.Group(group_code="alas", group_name="...")
+    db.session.add(group_2)
+    db.session.commit()
+
+    # Test wrong permissions
+    login_as("user")
+    assert client.get("/api/groups/alas").status_code == 403
+
+    # Test and validate success based on user's permissions
+    login_as("user")
+    response = client.get("/api/groups/ach")
+    assert response.status_code == 200
+    assert response.get_json()["group_name"] == "Alberta"
+
+
+# DELETE /api/groups/:id
+
+
+def test_delete_group(test_database, client, login_as):
+    # Simulate minio group equivalent of test_database
+    minioAdmin = MinioAdmin(
+        endpoint=TestConfig.MINIO_ENDPOINT,
+        access_key=TestConfig.MINIO_ACCESS_KEY,
+        secret_key=TestConfig.MINIO_SECRET_KEY,
+    )
+    minioAdmin.add_user("user", "useruser")
+    minioAdmin.group_add("ach", "user")
+
+    # Test without permission
+    login_as("user")
+    response = client.delete("/api/groups/haha")
+    assert response.status_code == 401
+
+    # Test with wrong code
+    login_as("admin")
+    response = client.delete("/api/groups/noCodeHere")
+    assert response.status_code == 404
+
+    # Test with user in it
+    login_as("admin")
+    response = client.delete("/api/groups/ach")
+    assert response.status_code == 422
+
+    # Standard test, need to clear users first
+    group = models.Group.query.filter_by(group_code="ach").one_or_none()
+    group.users = []
+
+    db.session.commit()
+    minioAdmin.remove_user("user")
+
+    login_as("admin")
+    assert client.delete("/api/groups/ach").status_code == 204
+
+    # Make sure it's gone
+    group = models.Group.query.filter_by(group_code="ach").one_or_none()
+    assert group == None
+    assert len(minioAdmin.list_groups()) == 0
+
+"""
+
+
+# PATCH /api/groups/:id
+
+
+def test_update_family(test_database, client, login_as):
+    login_as("user")
+    # Test existence
+    assert (
+        client.patch("/api/groups/4", json={"family_codename": "C"}).status_code
+        == 404
+    )
+
+    # Test permission
+    assert (
+        client.patch("/api/groups/2", json={"family_codename": "C"}).status_code
+        == 404
+    )
+
+    # Test no codename error
+    assert (
+        client.patch(
+            "/api/groups/2",
+            json={"Haha you thought it was a codename": "but it was I, useless json"},
+        ).status_code
+        == 400
+    )
+
+    # Test success
+    assert (
+        client.patch("/api/groups/1", json={"family_codename": "C"}).status_code
+        == 200
+    )
+    # Make sure it updated
+    family = models.Family.query.filter(models.Family.family_id == 1).one_or_none()
+    assert family.family_codename == "C"
+
+
+# POST /api/groups
+
+
+def test_create_family(test_database, client, login_as):
+    login_as("user")
+    assert client.post("/api/groups").status_code == 401
+
+    login_as("admin")
+    # Test no codename given
+    assert (
+        client.post(
+            "/api/groups",
+            json={"Haha you thought it was a codename": "but it was I, useless json"},
+        ).status_code
+        == 400
+    )
+    # Test codename already in use
+    assert (
+        client.post(
+            "/api/groups",
+            json={"family_codename": "A"},
+        ).status_code
+        == 422
+    )
+    # Test success and check db
+    assert (
+        client.post(
+            "/api/groups",
+            json={
+                "family_codename": "C",
+            },
+        ).status_code
+        == 201
+    )
+    family = models.Family.query.filter(
+        models.Family.family_codename == "C"
+    ).one_or_none()
+    assert family is not None
+
+    login_as("admin")
+    assert len(client.get("/api/groups").get_json()) == 3
+"""

--- a/flask/tests/test_groups.py
+++ b/flask/tests/test_groups.py
@@ -5,6 +5,7 @@ from conftest import TestConfig
 from app.madmin import MinioAdmin, readwrite_buckets_policy
 from minio import Minio
 
+
 @pytest.fixture
 def minioAdmin():
     madmin = MinioAdmin(
@@ -36,6 +37,7 @@ def minioAdmin():
         madmin.remove_policy("ach")
     except:
         pass
+
 
 # Tests
 
@@ -136,9 +138,6 @@ def test_delete_group(test_database, client, login_as, minioAdmin):
     assert len(minioAdmin.list_groups()) == 0
 
 
-
-
-
 # PATCH /api/groups/:id
 
 
@@ -146,8 +145,7 @@ def test_update_group(test_database, client, login_as, minioAdmin):
     login_as("admin")
     # Test existence
     assert (
-        client.patch("/api/groups/code", json={"group_name": "yes"}).status_code
-        == 404
+        client.patch("/api/groups/code", json={"group_name": "yes"}).status_code == 404
     )
 
     # Test success and check db and minio
@@ -156,18 +154,24 @@ def test_update_group(test_database, client, login_as, minioAdmin):
     user = models.User.query.filter(models.User.username == "user").one_or_none()
     user.minio_access_key = "user"
     assert (
-        client.patch("/api/groups/ach", json={"group_name": "Alberta2", "users": ["admin"]}).status_code
+        client.patch(
+            "/api/groups/ach", json={"group_name": "Alberta2", "users": ["admin"]}
+        ).status_code
         == 200
     )
     # Make sure it updated
-    group = models.Group.query.filter(models.Group.group_name == "Alberta2").one_or_none()
+    group = models.Group.query.filter(
+        models.Group.group_name == "Alberta2"
+    ).one_or_none()
     assert group is not None
     assert len(group.users) == 1
     assert group.users[0].username == "admin"
 
     # Reset
     assert (
-        client.patch("/api/groups/ach", json={"group_name": "Alberta", "users": ["user"]}).status_code
+        client.patch(
+            "/api/groups/ach", json={"group_name": "Alberta", "users": ["user"]}
+        ).status_code
         == 200
     )
 
@@ -201,16 +205,11 @@ def test_create_group(test_database, client, login_as, minioAdmin):
     assert (
         client.post(
             "/api/groups",
-            json={
-                "group_code": "code",
-                "group_name": "Actually nothing suspicious"
-            },
+            json={"group_code": "code", "group_name": "Actually nothing suspicious"},
         ).status_code
         == 201
     )
-    group = models.Group.query.filter(
-        models.Group.group_code == "code"
-    ).one_or_none()
+    group = models.Group.query.filter(models.Group.group_code == "code").one_or_none()
     assert group is not None
     assert len(minioAdmin.list_policies()) == 6
     minioClient = Minio(
@@ -233,16 +232,12 @@ def test_create_group(test_database, client, login_as, minioAdmin):
             json={
                 "group_code": "code2",
                 "group_name": "Actually nothing else suspicious",
-                "users": [
-                    "user"
-                ]
+                "users": ["user"],
             },
         ).status_code
         == 201
     )
-    group = models.Group.query.filter(
-        models.Group.group_code == "code2"
-    ).one_or_none()
+    group = models.Group.query.filter(models.Group.group_code == "code2").one_or_none()
     assert group is not None
     assert len(minioAdmin.list_policies()) == 6
     assert len(minioAdmin.get_group("code2")["members"]) == 1

--- a/flask/tests/test_groups.py
+++ b/flask/tests/test_groups.py
@@ -148,11 +148,6 @@ def test_update_group(test_database, client, login_as, minio_admin):
         client.patch("/api/groups/code", json={"group_name": "yes"}).status_code == 404
     )
 
-    # Test success and check db and minio
-    # ad = models.User.query.filter(models.User.username == "admin").one_or_none()
-    # ad.minio_access_key = "admin"
-    # user = models.User.query.filter(models.User.username == "user").one_or_none()
-    # user.minio_access_key = "user"
     assert (
         client.patch(
             "/api/groups/ach", json={"group_name": "Alberta2", "users": ["admin"]}

--- a/flask/tests/test_groups.py
+++ b/flask/tests/test_groups.py
@@ -2,7 +2,40 @@ import pytest
 from app import db, models
 from sqlalchemy.orm import joinedload
 from conftest import TestConfig
-from app.madmin import MinioAdmin
+from app.madmin import MinioAdmin, readwrite_buckets_policy
+from minio import Minio
+
+@pytest.fixture
+def minioAdmin():
+    madmin = MinioAdmin(
+        endpoint=TestConfig.MINIO_ENDPOINT,
+        access_key=TestConfig.MINIO_ACCESS_KEY,
+        secret_key=TestConfig.MINIO_SECRET_KEY,
+    )
+    # To match test_database on the minio side
+    madmin.add_user("user", "useruser")
+    madmin.add_user("admin", "adminadmin")
+    madmin.group_add("ach", "user")
+    madmin.add_policy("ach", readwrite_buckets_policy("ach"))
+    madmin.set_policy("ach", group="ach")
+    yield madmin
+    # Teardown
+    try:
+        madmin.remove_user("user")
+    except:
+        pass
+    try:
+        madmin.remove_user("admin")
+    except:
+        pass
+    try:
+        madmin.group_remove("ach")
+    except:
+        pass
+    try:
+        madmin.remove_policy("ach")
+    except:
+        pass
 
 # Tests
 
@@ -70,15 +103,7 @@ def test_get_group(test_database, client, login_as):
 # DELETE /api/groups/:id
 
 
-def test_delete_group(test_database, client, login_as):
-    # Simulate minio group equivalent of test_database
-    minioAdmin = MinioAdmin(
-        endpoint=TestConfig.MINIO_ENDPOINT,
-        access_key=TestConfig.MINIO_ACCESS_KEY,
-        secret_key=TestConfig.MINIO_SECRET_KEY,
-    )
-    minioAdmin.add_user("user", "useruser")
-    minioAdmin.group_add("ach", "user")
+def test_delete_group(test_database, client, login_as, minioAdmin):
 
     # Test without permission
     login_as("user")
@@ -111,84 +136,124 @@ def test_delete_group(test_database, client, login_as):
     assert len(minioAdmin.list_groups()) == 0
 
 
-"""
+
 
 
 # PATCH /api/groups/:id
 
 
-def test_update_family(test_database, client, login_as):
-    login_as("user")
+def test_update_group(test_database, client, login_as, minioAdmin):
+    login_as("admin")
     # Test existence
     assert (
-        client.patch("/api/groups/4", json={"family_codename": "C"}).status_code
+        client.patch("/api/groups/code", json={"group_name": "yes"}).status_code
         == 404
     )
 
-    # Test permission
+    # Test success and check db and minio
+    ad = models.User.query.filter(models.User.username == "admin").one_or_none()
+    ad.minio_access_key = "admin"
+    user = models.User.query.filter(models.User.username == "user").one_or_none()
+    user.minio_access_key = "user"
     assert (
-        client.patch("/api/groups/2", json={"family_codename": "C"}).status_code
-        == 404
-    )
-
-    # Test no codename error
-    assert (
-        client.patch(
-            "/api/groups/2",
-            json={"Haha you thought it was a codename": "but it was I, useless json"},
-        ).status_code
-        == 400
-    )
-
-    # Test success
-    assert (
-        client.patch("/api/groups/1", json={"family_codename": "C"}).status_code
+        client.patch("/api/groups/ach", json={"group_name": "Alberta2", "users": ["admin"]}).status_code
         == 200
     )
     # Make sure it updated
-    family = models.Family.query.filter(models.Family.family_id == 1).one_or_none()
-    assert family.family_codename == "C"
+    group = models.Group.query.filter(models.Group.group_name == "Alberta2").one_or_none()
+    assert group is not None
+    assert len(group.users) == 1
+    assert group.users[0].username == "admin"
+
+    # Reset
+    assert (
+        client.patch("/api/groups/ach", json={"group_name": "Alberta", "users": ["user"]}).status_code
+        == 200
+    )
 
 
 # POST /api/groups
 
 
-def test_create_family(test_database, client, login_as):
+def test_create_group(test_database, client, login_as, minioAdmin):
     login_as("user")
     assert client.post("/api/groups").status_code == 401
 
     login_as("admin")
-    # Test no codename given
+    # Test no group_code given
     assert (
         client.post(
             "/api/groups",
-            json={"Haha you thought it was a codename": "but it was I, useless json"},
+            json={"A json you say?": "How could you possibly be so naive"},
         ).status_code
         == 400
     )
-    # Test codename already in use
+    # Test group_code already in use
     assert (
         client.post(
             "/api/groups",
-            json={"family_codename": "A"},
+            json={"group_code": "ach", "group_name": "Nothing suspicious"},
         ).status_code
         == 422
     )
-    # Test success and check db
+
+    # Test success with no users and check db and minio
     assert (
         client.post(
             "/api/groups",
             json={
-                "family_codename": "C",
+                "group_code": "code",
+                "group_name": "Actually nothing suspicious"
             },
         ).status_code
         == 201
     )
-    family = models.Family.query.filter(
-        models.Family.family_codename == "C"
+    group = models.Group.query.filter(
+        models.Group.group_code == "code"
     ).one_or_none()
-    assert family is not None
+    assert group is not None
+    assert len(minioAdmin.list_policies()) == 6
+    minioClient = Minio(
+        TestConfig.MINIO_ENDPOINT,
+        access_key=TestConfig.MINIO_ACCESS_KEY,
+        secret_key=TestConfig.MINIO_SECRET_KEY,
+        secure=False,
+    )
+    # Clean up
+    minioClient.remove_bucket("code")
+    minioAdmin.remove_policy("code")
 
-    login_as("admin")
-    assert len(client.get("/api/groups").get_json()) == 3
-"""
+    # Test success with users and check db and minio
+    user = models.User.query.filter(models.User.username == "user").one_or_none()
+    user.minio_access_key = "user"
+
+    assert (
+        client.post(
+            "/api/groups",
+            json={
+                "group_code": "code2",
+                "group_name": "Actually nothing else suspicious",
+                "users": [
+                    "user"
+                ]
+            },
+        ).status_code
+        == 201
+    )
+    group = models.Group.query.filter(
+        models.Group.group_code == "code2"
+    ).one_or_none()
+    assert group is not None
+    assert len(minioAdmin.list_policies()) == 6
+    assert len(minioAdmin.get_group("code2")["members"]) == 1
+    minioClient = Minio(
+        TestConfig.MINIO_ENDPOINT,
+        access_key=TestConfig.MINIO_ACCESS_KEY,
+        secret_key=TestConfig.MINIO_SECRET_KEY,
+        secure=False,
+    )
+    # Clean up
+    minioClient.remove_bucket("code2")
+    minioAdmin.remove_policy("code2")
+    minioAdmin.remove_user("user")
+    minioAdmin.group_remove("code2")


### PR DESCRIPTION
closes #192 

Sample tests, will not work as expected unless User.minio_access_key and User.minio_secret_key are manually set to a manually created minio user:
```
curl -D - -X POST \
        -H "Content-Type: application/json" \
        --data '{"group_name" : "bruh20", "group_code" : "whoknows20",
                "users": [
                "admin"
                ]
                }' \
        localhost:5000/api/groups

curl -D - -X PATCH \
        -H "Content-Type: application/json" \
        --data '{"group_name" : "changed20.1",
                "users": [
                
                ]
                }' \
        localhost:5000/api/groups/whoknows20

curl -D - -X DELETE \
        localhost:5000/api/groups/whoknows20
```