### PR TITLE
nginx: forward MinIO on port 9000, other production fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ COPY --from=mc /usr/bin/mc /usr/bin/mc
 COPY . .
 EXPOSE 5000
 ENTRYPOINT ["./utils/wait-for-it.sh", "mysql:3306", "--timeout=0", "--", "./utils/run.sh"]
-CMD ["prod --bind 0.0.0.0:5000 --preload --workers 1 --threads 2"]
+CMD ["prod", "--bind", "0.0.0.0:5000", "--preload", "--workers", "1", "--threads", "2"]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.8"
 
 services:
   mysql:
@@ -23,7 +23,7 @@ services:
   app:
     build:
       context: flask
-      dockerfile: Dockerfile
+      dockerfile: ../Dockerfile
     image: ccmbio/st2020:edge
     environment:
       FLASK_ENV: production
@@ -39,6 +39,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
+      - "9000:9000"
     volumes:
       - ./react/build:/var/www/sample-tracker/react/build
       - ./nginx/conf.d:/etc/nginx/conf.d

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.8"
 
 services:
   mysql:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3.8"
 
 services:
   mysql:

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -8,7 +8,7 @@ server {
   listen 443 ssl default_server;
   listen [::]:443 ssl default_server;
   server_name _;
-  ssl_certificate /etc/nginx/certs/star_ccm_sickkids_ca.crt;
+  ssl_certificate /etc/nginx/certs/bundle.crt;
   ssl_certificate_key /etc/nginx/certs/star_ccm_sickkids_ca.key;
 
   location / {
@@ -26,17 +26,27 @@ server {
     client_max_body_size 5M;
     dav_methods PUT;
   }
-  location /minio {
+}
+server {
+  listen 9000 ssl default_server;
+  listen [::]:9000 ssl default_server;
+  server_name _;
+  ssl_certificate /etc/nginx/certs/bundle.crt;
+  ssl_certificate_key /etc/nginx/certs/star_ccm_sickkids_ca.key;
+  error_page 497 https://$host:$server_port$request_uri;
+  ignore_invalid_headers off;
+  client_max_body_size 0;
+  proxy_buffering off;
+
+  location / {
     proxy_pass "http://minio:9000";
     proxy_connect_timeout 300;
-    proxy_buffering off;
     proxy_http_version 1.1;
-    proxy_set_header Connection "";
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
     chunked_transfer_encoding off;
-    client_max_body_size 0;
   }
 }


### PR DESCRIPTION
nginx: [forward MinIO](https://docs.min.io/docs/setup-nginx-proxy-with-minio.html) on port 9000 again
nginx: fix public certificate path to use bundle with full certificate chain
compose: use latest version 3.8
compose: use correct prod app Dockerfile and fix CMD syntax