### PR TITLE
Test Scoping

### DIFF
--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -35,7 +35,7 @@ def application():
     yield test_app
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def client(application):
     """
     A test client that can issue requests.


### PR DESCRIPTION
closes #250 

The way Flask intended for tests to be written via pytest is with 1 request per function, and the test_client as a fixture with scope function. I think that is way to verbose and don't want to go back and change that, so I set the test_client to function scope which will stop app context errors across functions (because that would be next to impossible to debug).

I say we just ignore that the requests within one function share the same context and keep the possible error in mind, thoughts @kevinlul ?