### PR TITLE
Require sequencing_date at the API level but not the database level

### DIFF
--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -226,6 +226,10 @@ def create_dataset():
     if not tissue_sample_id:
         return "A tissue sample id must be provided", 400
 
+    sequencing_date = request.json.get("sequencing_date")
+    if not sequencing_date:
+        return "A sequencing date must be provided", 400
+
     models.TissueSample.query.filter_by(
         tissue_sample_id=tissue_sample_id
     ).first_or_404()

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -328,6 +328,10 @@ def bulk_update():
         created_by_id = 1
 
     for i, row in enumerate(dat):
+        sequencing_date = row.get("sequencing_date")
+        if not sequencing_date:
+            return "A sequencing date must be provided", 400
+
         # Find the family by codename or create it if it doesn't exist
         family_id = models.Family.query.filter(
             models.Family.family_codename == row.get("family_codename")

--- a/flask/tests/samplecsv.csv
+++ b/flask/tests/samplecsv.csv
@@ -1,7 +1,7 @@
 participant_codename,family_codename,tissue_sample_type,dataset_type,affected,participant_type,sex,month_of_birth,solved,condition,extraction_protocol,capture_kit,library_prep_method,read_length,read_type,sequencing_id,sequencing_date,sequencing_centre,batch_id
-PTP01,FAM01,Blood,WES,TRUE,Parent,Male,2016-01-01,FALSE,Control,Something,,,,PairedEnd,,,,
-PTP02,FAM01,Blood,WES,FALSE,Parent,Female,2012-01-01,FALSE,GermLine,Something,,,,SingleEnd,,,,
-PTP03,FAM01,Blood,WES,TRUE,Proband,Female,2000-06-01,FALSE,GermLine,Something,,,,PairedEnd,,,,
-BBB01,FAM02,Saliva,WES,FALSE,Parent,Male,1990-08-01,TRUE,GermLine,Something,,,,SingleEnd,,,,
-BBB02,FAM02,Saliva,WGS,TRUE,Parent,Male,1970-01-01,TRUE,GermLine,Something,,,,PairedEnd,,,,
-BBB03,FAM03,Saliva,WGS,TRUE,Proband,Female,1980-01-01,TRUE,GermLine,Something,,,,SingleEnd,,,,
+PTP01,FAM01,Blood,WES,TRUE,Parent,Male,2016-01-01,FALSE,Control,Something,,,,PairedEnd,,2020-12-17,,
+PTP02,FAM01,Blood,WES,FALSE,Parent,Female,2012-01-01,FALSE,GermLine,Something,,,,SingleEnd,,2020-12-17,,
+PTP03,FAM01,Blood,WES,TRUE,Proband,Female,2000-06-01,FALSE,GermLine,Something,,,,PairedEnd,,2020-12-17,,
+BBB01,FAM02,Saliva,WES,FALSE,Parent,Male,1990-08-01,TRUE,GermLine,Something,,,,SingleEnd,,2020-12-17,,
+BBB02,FAM02,Saliva,WGS,TRUE,Parent,Male,1970-01-01,TRUE,GermLine,Something,,,,PairedEnd,,2020-12-17,,
+BBB03,FAM03,Saliva,WGS,TRUE,Proband,Female,1980-01-01,TRUE,GermLine,Something,,,,SingleEnd,,2020-12-17,,

--- a/flask/tests/test_datasets.py
+++ b/flask/tests/test_datasets.py
@@ -226,21 +226,43 @@ def test_create_dataset(client, test_database, login_as):
     # Nonexistent tissue sample
     assert (
         client.post(
-            "/api/datasets", json={"dataset_type": "foo", "tissue_sample_id": "foo"}
+            "/api/datasets",
+            json={
+                "dataset_type": "foo",
+                "sequencing_date": "2020-12-04",
+                "tissue_sample_id": "foo",
+            },
         ).status_code
         == 404
     )
     assert (
         client.post(
-            "/api/datasets", json={"dataset_type": "foo", "tissue_sample_id": 400}
+            "/api/datasets",
+            json={
+                "dataset_type": "foo",
+                "sequencing_date": "2020-12-04",
+                "tissue_sample_id": 400,
+            },
         ).status_code
         == 404
+    )
+    # No sequencing date
+    assert (
+        client.post(
+            "/api/datasets", json={"dataset_type": "WGS", "tissue_sample_id": 1}
+        ).status_code
+        == 400
     )
 
     # Successful minimal create
     response = client.post(
         "/api/datasets",
-        json={"dataset_type": "WGS", "tissue_sample_id": 1, "condition": "Somatic"},
+        json={
+            "dataset_type": "WGS",
+            "tissue_sample_id": 1,
+            "condition": "Somatic",
+            "sequencing_date": "2020-12-04",
+        },
     )
     assert response.status_code == 201
     dataset = response.get_json()

--- a/flask/tests/test_misc.py
+++ b/flask/tests/test_misc.py
@@ -92,6 +92,7 @@ def test_post_bulk(test_database, client, login_as):
                     "tissue_sample_type": "Blood",
                     "dataset_type": "WGS",
                     "condition": "GermLine",
+                    "sequencing_date": "2020-12-17",
                 },
                 {
                     "family_codename": "1001",
@@ -100,6 +101,7 @@ def test_post_bulk(test_database, client, login_as):
                     "tissue_sample_type": "Blood",
                     "dataset_type": "WES",
                     "condition": "GermLine",
+                    "sequencing_date": "2020-12-17",
                 },
             ],
         ).status_code
@@ -114,6 +116,32 @@ def test_post_bulk(test_database, client, login_as):
             headers={"Content-Type": "text/csv"},
         ).status_code
         == 200
+    )
+
+    # Test sequencing_date is provided
+    assert (
+        client.post(
+            "/api/_bulk",
+            json=[
+                {
+                    "family_codename": "1001",
+                    "participant_codename": "1411",
+                    "tissue_sample": "Blood",
+                    "tissue_sample_type": "Blood",
+                    "dataset_type": "WGS",
+                    "condition": "GermLine",
+                },
+                {
+                    "family_codename": "1001",
+                    "participant_codename": "3420",
+                    "tissue_sample": "Blood",
+                    "tissue_sample_type": "Blood",
+                    "dataset_type": "WES",
+                    "condition": "GermLine",
+                },
+            ],
+        ).status_code
+        == 400
     )
 
     # Check db for both csv result and json array result
@@ -162,9 +190,9 @@ def test_bulk_multiple_csv(test_database, client, login_as):
         client.post(
             "/api/_bulk",
             data="""
-family_codename,participant_codename,participant_type,tissue_sample_type,dataset_type,sex,condition,linked_files,notes
-HOOD,HERO,Proband,Saliva,WGS,Female,GermLine,/path/foo|/path/bar||,
-HOOD,HERO,Proband,Saliva,WGS,Female,GermLine,/path/yeet|/path/cross|/foo/bar,three
+family_codename,participant_codename,participant_type,tissue_sample_type,dataset_type,sex,condition,sequencing_date,linked_files,notes
+HOOD,HERO,Proband,Saliva,WGS,Female,GermLine,2020-12-17,/path/foo|/path/bar||,
+HOOD,HERO,Proband,Saliva,WGS,Female,GermLine,2020-12-17,/path/yeet|/path/cross|/foo/bar,three
 """,
             headers={"Content-Type": "text/csv"},
         ).status_code
@@ -195,6 +223,7 @@ def test_bulk_multiple_json(test_database, client, login_as):
                     "dataset_type": "WGS",
                     "sex": "Female",
                     "condition": "GermLine",
+                    "sequencing_date": "2020-12-17",
                     "linked_files": ["/otonashi/yuzuru", "/tachibana/kanade"],
                 },
                 {
@@ -205,6 +234,7 @@ def test_bulk_multiple_json(test_database, client, login_as):
                     "dataset_type": "WES",
                     "sex": "Female",
                     "condition": "GermLine",
+                    "sequencing_date": "2020-12-17",
                     "linked_files": [
                         "",
                         "/perfectly/balanced",

--- a/react/src/AddDatasets/components/DataEntryTable.tsx
+++ b/react/src/AddDatasets/components/DataEntryTable.tsx
@@ -45,7 +45,7 @@ const useTableStyles = makeStyles(theme => ({
     },
 }));
 
-const fallbackColumns = ["notes", "sex", "input_hpf_path"];
+const fallbackColumns = ["notes", "sex", "input_hpf_path", "sequencing_date"];
 
 function getEnvColumns(): Array<keyof DataEntryRowOptional> {
     const envCols = process.env.REACT_APP_DEFAULT_OPTIONAL_COLUMNS;


### PR DESCRIPTION
closes #223

```
curl -X POST \
    -H "Content-Type: application/json"  \
    --data '{
            "tissue_sample_id": "1",
            "dataset_type": "CES",
            "input_hpf_path": "/hpf/CES",
            "notes": "blahblah",
            "condition": "GermLine",
            "extraction_protocol": "Something",
            "capture_kit": "capture kit x",
            "read_length": "150",
            "read_type": "PairedEnd",
            "discriminator": "dataset",
            "sequencing_date": "2020-12-04"
        }' \
    localhost:3000/api/datasets
```