### PR TITLE
React: Detail Dialog refactor

### DIFF
--- a/react/src/pages/datasets/DatasetInfoDialog.tsx
+++ b/react/src/pages/datasets/DatasetInfoDialog.tsx
@@ -45,7 +45,7 @@ interface DialogProp {
     onUpdate: (dataset_id: string, newDataset: { [key: string]: any }) => void;
 }
 
-export default function DatasetInfoDialog({ dataset, open, onClose, onUpdate }: DialogProp) {
+export default function DatasetInfoDialog(props: DialogProp) {
     const classes = useStyles();
     const labeledBy = "dataset-info-dialog-slide-title";
 
@@ -68,7 +68,7 @@ export default function DatasetInfoDialog({ dataset, open, onClose, onUpdate }: 
     }, []);
 
     useEffect(() => {
-        fetch("/api/datasets/" + dataset.dataset_id)
+        fetch("/api/datasets/" + props.dataset.dataset_id)
             .then(response => response.json())
             .then(data => {
                 setAnalyses(data.analyses as Analysis[]);
@@ -77,30 +77,30 @@ export default function DatasetInfoDialog({ dataset, open, onClose, onUpdate }: 
             .catch(error => {
                 console.error(error);
             });
-    }, [dataset]);
+    }, [props.dataset]);
 
     return (
-        <Dialog onClose={onClose} aria-labelledby={labeledBy} open={open} maxWidth="lg" fullWidth>
+        <Dialog onClose={props.onClose} aria-labelledby={labeledBy} open={props.open} maxWidth="lg" fullWidth>
             <DialogHeader
                 id={labeledBy}
-                onClose={() => {
-                    onClose();
-                }}
+                onClose={
+                    props.onClose
+                }
             >
-                Details of Dataset ID {dataset.dataset_id}
+                Details of Dataset ID {props.dataset.dataset_id}
             </DialogHeader>
             <DialogContent className={classes.datasetInfo} dividers>
                 <div className={classes.infoSection}>
-                    {dataset && (
+                    {props.dataset && (
                         <DetailSection
-                            fields={getDatasetFields(dataset)}
+                            fields={getDatasetFields(props.dataset)}
                             enums={enums}
-                            collapsibleFields={getSecDatasetFields(dataset)}
+                            collapsibleFields={getSecDatasetFields(props.dataset)}
                             dataInfo={{
                                 type: "dataset",
-                                ID: dataset.dataset_id,
-                                identifier: dataset.dataset_id,
-                                onUpdate: onUpdate,
+                                ID: props.dataset.dataset_id,
+                                identifier: props.dataset.dataset_id,
+                                onUpdate: props.onUpdate,
                             }}
                         />
                     )}

--- a/react/src/pages/datasets/DatasetInfoDialog.tsx
+++ b/react/src/pages/datasets/DatasetInfoDialog.tsx
@@ -80,13 +80,14 @@ export default function DatasetInfoDialog(props: DialogProp) {
     }, [props.dataset]);
 
     return (
-        <Dialog onClose={props.onClose} aria-labelledby={labeledBy} open={props.open} maxWidth="lg" fullWidth>
-            <DialogHeader
-                id={labeledBy}
-                onClose={
-                    props.onClose
-                }
-            >
+        <Dialog
+            onClose={props.onClose}
+            aria-labelledby={labeledBy}
+            open={props.open}
+            maxWidth="lg"
+            fullWidth
+        >
+            <DialogHeader id={labeledBy} onClose={props.onClose}>
                 Details of Dataset ID {props.dataset.dataset_id}
             </DialogHeader>
             <DialogContent className={classes.datasetInfo} dividers>

--- a/react/src/pages/datasets/DatasetInfoDialog.tsx
+++ b/react/src/pages/datasets/DatasetInfoDialog.tsx
@@ -52,6 +52,21 @@ export default function DatasetInfoDialog({ dataset, open, onClose, onUpdate }: 
     const [analyses, setAnalyses] = useState<Analysis[]>([]);
     const [sample, setSample] = useState<Sample>();
 
+    const [enums, setEnums] = useState<any>();
+
+    useEffect(() => {
+        fetch("/api/enums").then(async response => {
+            if (response.ok) {
+                const enums = await response.json();
+                setEnums(enums);
+            } else {
+                console.error(
+                    `GET /api/enums failed with ${response.status}: ${response.statusText}`
+                );
+            }
+        });
+    }, []);
+
     useEffect(() => {
         fetch("/api/datasets/" + dataset.dataset_id)
             .then(response => response.json())
@@ -79,6 +94,7 @@ export default function DatasetInfoDialog({ dataset, open, onClose, onUpdate }: 
                     {dataset && (
                         <DetailSection
                             fields={getDatasetFields(dataset)}
+                            enums={enums}
                             collapsibleFields={getSecDatasetFields(dataset)}
                             dataInfo={{
                                 type: "dataset",
@@ -94,6 +110,7 @@ export default function DatasetInfoDialog({ dataset, open, onClose, onUpdate }: 
                     {sample && (
                         <DetailSection
                             fields={getSamplesFields(sample)}
+                            enums={enums}
                             title="Associated Tissue Sample"
                         />
                     )}
@@ -104,6 +121,7 @@ export default function DatasetInfoDialog({ dataset, open, onClose, onUpdate }: 
                         <InfoList
                             infoList={getAnalysisInfoList(analyses)}
                             title="Analyses which use this dataset"
+                            enums={enums}
                             icon={<ShowChart />}
                             linkPath="/analysis"
                         />

--- a/react/src/pages/participants/ParticipantInfoDialog.tsx
+++ b/react/src/pages/participants/ParticipantInfoDialog.tsx
@@ -57,8 +57,21 @@ export default function ParticipantInfoDialog({
     const classes = useStyles();
     const labeledBy = "participant-info-dialog-slide-title";
     const [analyses, setAnalyses] = useState<Analysis[]>([]);
-
     const { enqueueSnackbar } = useSnackbar();
+    const [enums, setEnums] = useState<any>();
+
+    useEffect(() => {
+        fetch("/api/enums").then(async response => {
+            if (response.ok) {
+                const enums = await response.json();
+                setEnums(enums);
+            } else {
+                console.error(
+                    `GET /api/enums failed with ${response.status}: ${response.statusText}`
+                );
+            }
+        });
+    }, []);
 
     useEffect(() => {
         (async () => {
@@ -101,6 +114,7 @@ export default function ParticipantInfoDialog({
                 <div className={classes.infoSection}>
                     <DetailSection
                         fields={getParticipantFields(participant)}
+                        enums={enums}
                         dataInfo={{
                             type: "participant",
                             ID: participant.participant_id,
@@ -113,7 +127,7 @@ export default function ParticipantInfoDialog({
                     <>
                         <Divider />
                         <div>
-                            <SampleTable samples={participant.tissue_samples} />
+                            <SampleTable samples={participant.tissue_samples} enums={enums} />
                         </div>
                     </>
                 )}
@@ -124,6 +138,7 @@ export default function ParticipantInfoDialog({
                             <InfoList
                                 infoList={getAnalysisInfoList(analyses)}
                                 title="Analyses"
+                                enums={enums}
                                 icon={<ShowChart />}
                                 linkPath="/analysis"
                             />

--- a/react/src/pages/participants/ParticipantInfoDialog.tsx
+++ b/react/src/pages/participants/ParticipantInfoDialog.tsx
@@ -48,12 +48,7 @@ interface DialogProp {
     onUpdate: (participant_id: string, newParticipant: { [key: string]: any }) => void;
 }
 
-export default function ParticipantInfoDialog({
-    participant,
-    open,
-    onClose,
-    onUpdate,
-}: DialogProp) {
+export default function ParticipantInfoDialog(props: DialogProp) {
     const classes = useStyles();
     const labeledBy = "participant-info-dialog-slide-title";
     const [analyses, setAnalyses] = useState<Analysis[]>([]);
@@ -75,7 +70,7 @@ export default function ParticipantInfoDialog({
 
     useEffect(() => {
         (async () => {
-            const datasets = participant.tissue_samples.flatMap(sample => sample.datasets);
+            const datasets = props.participant.tissue_samples.flatMap(sample => sample.datasets);
             let analysisList: Analysis[] = [];
             for (const dataset of datasets) {
                 const response = await fetch("/api/datasets/" + dataset.dataset_id);
@@ -97,37 +92,37 @@ export default function ParticipantInfoDialog({
                 console.error(error);
                 enqueueSnackbar(error.message, { variant: "error" });
             });
-    }, [participant, enqueueSnackbar]);
+    }, [props.participant, enqueueSnackbar]);
 
     return (
         <Dialog
-            onClose={onClose}
+            onClose={props.onClose}
             aria-labelledby={labeledBy}
-            open={open}
+            open={props.open}
             maxWidth="lg"
             fullWidth={true}
         >
-            <DialogHeader id={labeledBy} onClose={onClose}>
-                Details of Participant {participant.participant_codename}
+            <DialogHeader id={labeledBy} onClose={props.onClose}>
+                Details of Participant {props.participant.participant_codename}
             </DialogHeader>
             <DialogContent className={classes.dialogContent} dividers>
                 <div className={classes.infoSection}>
                     <DetailSection
-                        fields={getParticipantFields(participant)}
+                        fields={getParticipantFields(props.participant)}
                         enums={enums}
                         dataInfo={{
                             type: "participant",
-                            ID: participant.participant_id,
-                            identifier: participant.participant_codename,
-                            onUpdate: onUpdate,
+                            ID: props.participant.participant_id,
+                            identifier: props.participant.participant_codename,
+                            onUpdate: props.onUpdate,
                         }}
                     />
                 </div>
-                {participant.tissue_samples.length > 0 && (
+                {props.participant.tissue_samples.length > 0 && (
                     <>
                         <Divider />
                         <div>
-                            <SampleTable samples={participant.tissue_samples} enums={enums} />
+                            <SampleTable samples={props.participant.tissue_samples} enums={enums} />
                         </div>
                     </>
                 )}

--- a/react/src/pages/participants/SampleTable.tsx
+++ b/react/src/pages/participants/SampleTable.tsx
@@ -36,7 +36,7 @@ function getFields(dataset: Dataset) {
     ];
 }
 
-export default function SampleTable({ samples }: { samples: Sample[] }) {
+export default function SampleTable(props: { samples: Sample[]; enums: any }) {
     const classes = useStyles();
 
     return (
@@ -64,7 +64,7 @@ export default function SampleTable({ samples }: { samples: Sample[] }) {
                 },
                 { title: "Updated By", field: "updated_by" },
             ]}
-            data={samples}
+            data={props.samples}
             title="Tissue Samples"
             detailPanel={rowData => {
                 const infoList: Info[] = rowData.datasets.map(dataset => {
@@ -75,7 +75,12 @@ export default function SampleTable({ samples }: { samples: Sample[] }) {
                 });
                 return (
                     <div className={classes.datasetList}>
-                        <InfoList infoList={infoList} icon={<Dns />} linkPath="/datasets" />
+                        <InfoList
+                            infoList={infoList}
+                            icon={<Dns />}
+                            linkPath="/datasets"
+                            enums={props.enums}
+                        />
                     </div>
                 );
             }}

--- a/react/src/pages/utils/components/AnalysisInfoDialog.tsx
+++ b/react/src/pages/utils/components/AnalysisInfoDialog.tsx
@@ -42,10 +42,23 @@ function getAnalysisFields(analysis: Analysis, pipeline: Pipeline | undefined) {
 
 export default function AnalysisInfoDialog({ analysis, open, onClose }: AlertInfoDialogProp) {
     const classes = useStyles();
-
     const [datasets, setDatasets] = useState<Dataset[]>([]);
     const [pipeline, setPipeline] = useState<Pipeline>();
     const labeledBy = "analysis-info-dialog-slide-title";
+    const [enums, setEnums] = useState<any>();
+
+    useEffect(() => {
+        fetch("/api/enums").then(async response => {
+            if (response.ok) {
+                const enums = await response.json();
+                setEnums(enums);
+            } else {
+                console.error(
+                    `GET /api/enums failed with ${response.status}: ${response.statusText}`
+                );
+            }
+        });
+    }, []);
 
     useEffect(() => {
         fetch("/api/analyses/" + analysis.analysis_id)
@@ -70,7 +83,7 @@ export default function AnalysisInfoDialog({ analysis, open, onClose }: AlertInf
             </DialogHeader>
             <DialogContent className={classes.dialogContent} dividers>
                 <div className={classes.infoSection}>
-                    <DetailSection fields={getAnalysisFields(analysis, pipeline)} />
+                    <DetailSection fields={getAnalysisFields(analysis, pipeline)} enums={enums} />
                 </div>
                 <Divider />
                 <div className={classes.infoSection}>
@@ -78,6 +91,7 @@ export default function AnalysisInfoDialog({ analysis, open, onClose }: AlertInf
                         <InfoList
                             infoList={getDatasetInfoList(datasets)}
                             title="Associated Datasets"
+                            enums={enums}
                             icon={<Dns />}
                             linkPath="/datasets"
                         />

--- a/react/src/pages/utils/components/AnalysisInfoDialog.tsx
+++ b/react/src/pages/utils/components/AnalysisInfoDialog.tsx
@@ -21,12 +21,6 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-interface AlertInfoDialogProp {
-    open: boolean;
-    analysis: Analysis;
-    onClose: () => void;
-}
-
 function getAnalysisFields(analysis: Analysis, pipeline: Pipeline | undefined) {
     return [
         createFieldObj("Assigned to", analysis.assignee),
@@ -40,7 +34,13 @@ function getAnalysisFields(analysis: Analysis, pipeline: Pipeline | undefined) {
     ];
 }
 
-export default function AnalysisInfoDialog({ analysis, open, onClose }: AlertInfoDialogProp) {
+interface AlertInfoDialogProp {
+    open: boolean;
+    analysis: Analysis;
+    onClose: () => void;
+}
+
+export default function AnalysisInfoDialog(props: AlertInfoDialogProp) {
     const classes = useStyles();
     const [datasets, setDatasets] = useState<Dataset[]>([]);
     const [pipeline, setPipeline] = useState<Pipeline>();
@@ -61,29 +61,29 @@ export default function AnalysisInfoDialog({ analysis, open, onClose }: AlertInf
     }, []);
 
     useEffect(() => {
-        fetch("/api/analyses/" + analysis.analysis_id)
+        fetch("/api/analyses/" + props.analysis.analysis_id)
             .then(response => response.json())
             .then(data => {
                 setDatasets(data.datasets);
                 setPipeline(data.pipeline);
             })
             .catch(error => {});
-    }, [analysis]);
+    }, [props.analysis]);
 
     return (
         <Dialog
-            onClose={onClose}
+            onClose={props.onClose}
             aria-labelledby={labeledBy}
-            open={open}
+            open={props.open}
             maxWidth="md"
             fullWidth={true}
         >
-            <DialogHeader id={labeledBy} onClose={onClose}>
-                Details of Analysis ID {analysis.analysis_id}
+            <DialogHeader id={labeledBy} onClose={props.onClose}>
+                Details of Analysis ID {props.analysis.analysis_id}
             </DialogHeader>
             <DialogContent className={classes.dialogContent} dividers>
                 <div className={classes.infoSection}>
-                    <DetailSection fields={getAnalysisFields(analysis, pipeline)} enums={enums} />
+                    <DetailSection fields={getAnalysisFields(props.analysis, pipeline)} enums={enums} />
                 </div>
                 <Divider />
                 <div className={classes.infoSection}>

--- a/react/src/pages/utils/components/AnalysisInfoDialog.tsx
+++ b/react/src/pages/utils/components/AnalysisInfoDialog.tsx
@@ -83,7 +83,10 @@ export default function AnalysisInfoDialog(props: AlertInfoDialogProp) {
             </DialogHeader>
             <DialogContent className={classes.dialogContent} dividers>
                 <div className={classes.infoSection}>
-                    <DetailSection fields={getAnalysisFields(props.analysis, pipeline)} enums={enums} />
+                    <DetailSection
+                        fields={getAnalysisFields(props.analysis, pipeline)}
+                        enums={enums}
+                    />
                 </div>
                 <Divider />
                 <div className={classes.infoSection}>

--- a/react/src/pages/utils/components/DetailSection.tsx
+++ b/react/src/pages/utils/components/DetailSection.tsx
@@ -4,44 +4,20 @@ import {
     Collapse,
     Grid,
     Typography,
-    TextField as MuiTextField,
-    Fade,
-    Box,
     makeStyles,
     IconButton,
     FormControlLabel,
     Switch,
-    MenuItem,
 } from "@material-ui/core";
 import { Check } from "@material-ui/icons";
 import { useSnackbar } from "notistack";
-import { FieldDisplayValueType, Field, PseudoBooleanReadableMap, PseudoBoolean } from "../typings";
+import { Field } from "../typings";
+import GridFieldsDisplay from "./GridFieldsDisplay";
 
 const gridSpacing = 2;
 const titleWidth = 12;
-const infoWidth = 6;
-
-const multilineFields = ["notes"];
-const enumFields = [
-    "sex",
-    "participant_type",
-    "condition",
-    "extraction_protocol",
-    "read_type",
-    "dataset_type",
-];
-const nonNullableFields = ["dataset_type", "condition"]; //does not include uneditable fields
-const booleanFields = ["affected", "solved"];
-const dateFields = ["library_prep_date"];
 
 const useStyles = makeStyles(theme => ({
-    textField: {
-        margin: theme.spacing(0.2),
-        width: "50%",
-    },
-    box: {
-        padding: theme.spacing(0.5),
-    },
     fieldDisplay: {
         textDecoration: "underline dotted",
     },
@@ -67,224 +43,6 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-const capitalizeFirstLetter = (s: string | undefined) => {
-    if (s) return s.charAt(0).toUpperCase() + s.slice(1);
-};
-
-const formatValue = (value: FieldDisplayValueType, nullUnknown: boolean = false) => {
-    let val = value;
-    if (Array.isArray(value)) val = value.join(", ");
-    else if (value === null || value === undefined)
-        nullUnknown ? (val = PseudoBooleanReadableMap[("" + value) as PseudoBoolean]) : (val = "");
-    else if (typeof value === "boolean")
-        val = PseudoBooleanReadableMap[("" + value) as PseudoBoolean];
-    return val;
-};
-
-interface FieldDisplayProps {
-    title: string;
-    value?: FieldDisplayValueType;
-    className?: string;
-    bool?: boolean;
-}
-/* Simple Typography component to display "title: value" */
-function FieldDisplay({ title, value, className, bool }: FieldDisplayProps) {
-    return (
-        <Typography variant="body1" gutterBottom>
-            <b>{title}:</b> <span className={className}>{formatValue(value, bool)}</span>
-        </Typography>
-    );
-}
-
-/* Given a fieldName of a Field object, return the corresponding field in enums */
-const getFieldInEnums = (fieldName: string): string => {
-    switch (fieldName) {
-        case "sex":
-            return "Sex";
-        case "participant_type":
-            return "ParticipantType";
-        case "condition":
-            return "DatasetCondition";
-        case "extraction_protocol":
-            return "DatasetExtractionProtocol";
-        case "read_type":
-            return "DatasetReadType";
-        case "dataset_type":
-            return "DatasetType";
-        default:
-            return "Sex";
-    }
-};
-
-function TextField({
-    field,
-    enums,
-    onEdit,
-}: {
-    field: Field;
-    enums: any;
-    onEdit: (fieldName: string | undefined, value: any) => void;
-}) {
-    const classes = useStyles();
-    const nullOption = (
-        <MenuItem value={""}>
-            <em>None</em>
-        </MenuItem>
-    );
-    if (!field.fieldName || !enums) return <></>;
-    if (enumFields.includes(field.fieldName)) {
-        return (
-            <MuiTextField
-                className={classes.textField}
-                margin="dense"
-                label={field.title}
-                value={formatValue(field.value)}
-                required={nonNullableFields.includes(field.fieldName)}
-                disabled={field.disableEdit}
-                select
-                onChange={e => {
-                    onEdit(field.fieldName, e.target.value === "" ? null : e.target.value);
-                }}
-            >
-                {enums[getFieldInEnums(field.fieldName)].map((option: string) => (
-                    <MenuItem key={option} value={option}>
-                        {option}
-                    </MenuItem>
-                ))}
-                {!nonNullableFields.includes(field.fieldName) && nullOption}
-            </MuiTextField>
-        );
-    } else if (booleanFields.includes(field.fieldName)) {
-        // Need to clean this up when refactoring this section
-        return (
-            <MuiTextField
-                className={classes.textField}
-                margin="dense"
-                label={field.title}
-                value={formatValue(field.value, true)}
-                required={nonNullableFields.includes(field.fieldName)}
-                disabled={field.disableEdit}
-                select
-                onChange={e => {
-                    let val;
-                    if (e.target.value === "No") val = false;
-                    else if (e.target.value === "Yes") val = true;
-                    else val = null;
-                    onEdit(field.fieldName, val);
-                }}
-            >
-                {["Yes", "No", "Unknown"].map((option: string) => (
-                    <MenuItem key={option} value={option}>
-                        {option}
-                    </MenuItem>
-                ))}
-            </MuiTextField>
-        );
-    } else if (multilineFields.includes(field.fieldName)) {
-        return (
-            <MuiTextField
-                className={classes.textField}
-                margin="dense"
-                label={field.title}
-                value={formatValue(field.value)}
-                required={nonNullableFields.includes(field.fieldName)}
-                disabled={field.disableEdit}
-                multiline
-                rowsMax={2}
-                onChange={e => onEdit(field.fieldName, e.target.value)}
-            />
-        );
-    } else if (dateFields.includes(field.fieldName)) {
-        return (
-            <MuiTextField
-                className={classes.textField}
-                margin="dense"
-                label={field.title}
-                value={formatValue(field.value)}
-                required={nonNullableFields.includes(field.fieldName)}
-                disabled={field.disableEdit}
-                InputLabelProps={{ shrink: true }}
-                type="date"
-                onChange={e => {
-                    onEdit(field.fieldName, e.target.value);
-                }}
-            />
-        );
-    }
-    return (
-        <MuiTextField
-            className={classes.textField}
-            margin="dense"
-            label={field.title}
-            value={formatValue(field.value)}
-            required={nonNullableFields.includes(field.fieldName)}
-            disabled={field.disableEdit}
-            onChange={e => onEdit(field.fieldName, e.target.value === "" ? null : e.target.value)}
-        />
-    );
-}
-
-function GridFieldsDisplay({
-    fields,
-    editMode,
-    position,
-    onEdit,
-}: {
-    fields: Field[];
-    editMode: boolean;
-    position: "left" | "right";
-    onEdit: (fieldName: string | undefined, value: any) => void;
-}) {
-    const classes = useStyles();
-    const [enums, setEnums] = useState(undefined);
-
-    useEffect(() => {
-        fetch("/api/enums").then(async response => {
-            if (response.ok) {
-                const enums = await response.json();
-                setEnums(enums);
-            } else {
-                console.error(
-                    `GET /api/enums failed with ${response.status}: ${response.statusText}`
-                );
-            }
-        });
-    }, []);
-
-    return (
-        <Grid item xs={infoWidth}>
-            {fields.map((field, index) => {
-                if (position === "left" && index >= Math.ceil(fields.length / 2)) {
-                    return <></>;
-                } else if (position === "right" && index < Math.ceil(fields.length / 2)) {
-                    return <></>;
-                } else {
-                    return (
-                        <>
-                            <Fade in={editMode}>
-                                <Box hidden={!editMode}>
-                                    <TextField field={field} enums={enums} onEdit={onEdit} />
-                                </Box>
-                            </Fade>
-                            <Fade in={!editMode}>
-                                <Box className={classes.box} hidden={editMode}>
-                                    <FieldDisplay
-                                        title={field.title}
-                                        value={field.value}
-                                        bool={
-                                            !!field.fieldName &&
-                                            !!booleanFields.includes(field.fieldName)
-                                        }
-                                    />
-                                </Box>
-                            </Fade>
-                        </>
-                    );
-                }
-            })}
-        </Grid>
-    );
-}
 interface DataInfo {
     type: "participant" | "dataset";
     ID: string;
@@ -370,7 +128,7 @@ export default function DetailSection({
             console.log(data);
             if (dataInfo?.onUpdate) dataInfo!.onUpdate(dataInfo.ID, data);
             enqueueSnackbar(
-                `${capitalizeFirstLetter(dataInfo?.type)} ${
+                `${dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${
                     dataInfo?.identifier
                 } updated successfully`,
                 {
@@ -411,13 +169,6 @@ export default function DetailSection({
                         fields={primaryFields}
                         editMode={editMode}
                         onEdit={OnEditData}
-                        position="left"
-                    />
-                    <GridFieldsDisplay
-                        fields={primaryFields}
-                        editMode={editMode}
-                        onEdit={OnEditData}
-                        position="right"
                     />
                 </Grid>
                 {dataInfo && (
@@ -461,13 +212,6 @@ export default function DetailSection({
                                 fields={secondaryFields}
                                 editMode={editMode}
                                 onEdit={OnEditData}
-                                position="left"
-                            />
-                            <GridFieldsDisplay
-                                fields={secondaryFields}
-                                editMode={editMode}
-                                onEdit={OnEditData}
-                                position="right"
                             />
                         </Grid>
                     </Collapse>

--- a/react/src/pages/utils/components/DetailSection.tsx
+++ b/react/src/pages/utils/components/DetailSection.tsx
@@ -63,6 +63,9 @@ export default function DetailSection(props: DetailSectionProps) {
     const classes = useStyles();
     const [moreDetails, setMoreDetails] = useState(false);
     const [editMode, setEditMode] = useState<boolean>(false);
+
+    // These keep track of state when editing
+    // When edit is finalized, send to backend to update props
     const [primaryFields, setPrimaryFields] = useState<Field[]>([]);
     const [secondaryFields, setSecondaryFields] = useState<Field[]>(
         props.collapsibleFields ? props.collapsibleFields : []
@@ -78,6 +81,7 @@ export default function DetailSection(props: DetailSectionProps) {
         setSecondaryFields(props.collapsibleFields ? props.collapsibleFields : []);
     }, [props.collapsibleFields]);
 
+    // Update field of name fieldName with new value
     function OnEditData(fieldName: string | undefined, value: any) {
         if (fieldName) {
             let idx = primaryFields.findIndex(element => element.fieldName === fieldName);

--- a/react/src/pages/utils/components/DetailSection.tsx
+++ b/react/src/pages/utils/components/DetailSection.tsx
@@ -52,35 +52,31 @@ interface DataInfo {
 
 interface DetailSectionProps {
     fields: Field[];
+    enums: any;
     collapsibleFields?: Field[];
     title?: string;
     dataInfo?: DataInfo; // dataInfo indicates data is editable
     linkPath?: string;
 }
 
-export default function DetailSection({
-    fields,
-    collapsibleFields,
-    title,
-    dataInfo,
-}: DetailSectionProps) {
+export default function DetailSection(props: DetailSectionProps) {
     const classes = useStyles();
     const [moreDetails, setMoreDetails] = useState(false);
     const [editMode, setEditMode] = useState<boolean>(false);
     const [primaryFields, setPrimaryFields] = useState<Field[]>([]);
     const [secondaryFields, setSecondaryFields] = useState<Field[]>(
-        collapsibleFields ? collapsibleFields : []
+        props.collapsibleFields ? props.collapsibleFields : []
     );
     const { enqueueSnackbar } = useSnackbar();
 
     // Props are the main source of truth about the state of the fields
     useEffect(() => {
-        setPrimaryFields(fields);
-    }, [fields]);
+        setPrimaryFields(props.fields);
+    }, [props.fields]);
 
     useEffect(() => {
-        setSecondaryFields(collapsibleFields ? collapsibleFields : []);
-    }, [collapsibleFields]);
+        setSecondaryFields(props.collapsibleFields ? props.collapsibleFields : []);
+    }, [props.collapsibleFields]);
 
     function OnEditData(fieldName: string | undefined, value: any) {
         if (fieldName) {
@@ -107,10 +103,10 @@ export default function DetailSection({
 
     async function updateData() {
         let url;
-        if (dataInfo?.type === "participant") {
-            url = `/api/participants/${dataInfo?.ID}`;
+        if (props.dataInfo?.type === "participant") {
+            url = `/api/participants/${props.dataInfo?.ID}`;
         } else {
-            url = `/api/datasets/${dataInfo?.ID}`;
+            url = `/api/datasets/${props.dataInfo?.ID}`;
         }
         const newData: { [key: string]: any } = {};
         primaryFields.concat(secondaryFields).forEach(field => {
@@ -126,25 +122,25 @@ export default function DetailSection({
         if (response.ok) {
             const data = await response.json();
             console.log(data);
-            if (dataInfo?.onUpdate) dataInfo!.onUpdate(dataInfo.ID, data);
+            if (props.dataInfo?.onUpdate) props.dataInfo!.onUpdate(props.dataInfo.ID, data);
             enqueueSnackbar(
-                `${dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${
-                    dataInfo?.identifier
+                `${props.dataInfo?.type.replace(/$(\w)/g, "$&".toUpperCase())} ${
+                    props.dataInfo?.identifier
                 } updated successfully`,
                 {
                     variant: "success",
                 }
             );
         } else {
-            setPrimaryFields(fields);
-            if (collapsibleFields) {
-                setSecondaryFields(collapsibleFields);
+            setPrimaryFields(props.fields);
+            if (props.collapsibleFields) {
+                setSecondaryFields(props.collapsibleFields);
             }
             console.error(
-                `PATCH /api/${dataInfo?.type}s/${dataInfo?.ID} failed with ${response.status}: ${response.statusText}`
+                `PATCH /api/${props.dataInfo?.type}s/${props.dataInfo?.ID} failed with ${response.status}: ${response.statusText}`
             );
             enqueueSnackbar(
-                `Failed to edit ${dataInfo?.type} ${dataInfo?.identifier} - ${response.status} ${response.statusText}`,
+                `Failed to edit ${props.dataInfo?.type} ${props.dataInfo?.identifier} - ${response.status} ${response.statusText}`,
                 { variant: "error" }
             );
         }
@@ -153,25 +149,26 @@ export default function DetailSection({
     return (
         <>
             <Grid container spacing={gridSpacing} justify="space-between">
-                {title && (
+                {props.title && (
                     <Grid item xs={titleWidth}>
-                        <Typography variant="h6">{title}</Typography>
+                        <Typography variant="h6">{props.title}</Typography>
                     </Grid>
                 )}
                 <Grid
                     container
                     spacing={gridSpacing}
                     item
-                    xs={dataInfo ? 10 : 12}
+                    xs={props.dataInfo ? 10 : 12}
                     justify="space-evenly"
                 >
                     <GridFieldsDisplay
                         fields={primaryFields}
                         editMode={editMode}
                         onEdit={OnEditData}
+                        enums={props.enums}
                     />
                 </Grid>
-                {dataInfo && (
+                {props.dataInfo && (
                     <Grid item xs={2}>
                         <FormControlLabel
                             control={<Switch color="primary" checked={editMode} size="small" />}
@@ -181,9 +178,9 @@ export default function DetailSection({
                             className={classes.switch}
                             onChange={() => {
                                 if (editMode) {
-                                    setPrimaryFields(fields);
-                                    if (collapsibleFields) {
-                                        setSecondaryFields(collapsibleFields);
+                                    setPrimaryFields(props.fields);
+                                    if (props.collapsibleFields) {
+                                        setSecondaryFields(props.collapsibleFields);
                                     }
                                 }
                                 setEditMode(!editMode);
@@ -204,7 +201,7 @@ export default function DetailSection({
                     </Grid>
                 )}
             </Grid>
-            {collapsibleFields && (
+            {props.collapsibleFields && (
                 <>
                     <Collapse in={moreDetails}>
                         <Grid container spacing={gridSpacing} justify="space-evenly">
@@ -212,6 +209,7 @@ export default function DetailSection({
                                 fields={secondaryFields}
                                 editMode={editMode}
                                 onEdit={OnEditData}
+                                enums={props.enums}
                             />
                         </Grid>
                     </Collapse>

--- a/react/src/pages/utils/components/FieldDisplay.tsx
+++ b/react/src/pages/utils/components/FieldDisplay.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Typography } from "@material-ui/core";
+import { FieldDisplayValueType } from "../typings";
+import { formatFieldValue } from "../functions";
+
+export interface FieldDisplayProps {
+    title: string;
+    value?: FieldDisplayValueType;
+    className?: string;
+    bool?: boolean;
+}
+
+/* Simple Typography component to display "title: value" */
+export default function FieldDisplay(props: FieldDisplayProps) {
+    return (
+        <Typography variant="body1" gutterBottom>
+            <b>{props.title}:</b>{" "}
+            <span className={props.className}>{formatFieldValue(props.value, props.bool)}</span>
+        </Typography>
+    );
+}

--- a/react/src/pages/utils/components/FieldDisplayEditable.tsx
+++ b/react/src/pages/utils/components/FieldDisplayEditable.tsx
@@ -1,0 +1,182 @@
+import { Box, Fade, makeStyles, MenuItem, TextField, TextFieldProps } from "@material-ui/core";
+import React from "react";
+import { formatFieldValue } from "../functions";
+import { Field, PseudoBooleanReadableMap } from "../typings";
+import FieldDisplay from "./FieldDisplay";
+
+// Alias for really long type
+type TextFieldEvent = React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>;
+
+const multilineFields = ["notes"];
+const enumFields = [
+    "sex",
+    "participant_type",
+    "condition",
+    "extraction_protocol",
+    "read_type",
+    "dataset_type",
+];
+const nonNullableFields = ["dataset_type", "condition"]; //does not include uneditable fields
+const booleanFields = ["affected", "solved"];
+const dateFields = ["library_prep_date"];
+
+/**
+ * Given a fieldName of a Field object, return the corresponding field in enums
+ */
+function getFieldInEnums(fieldName: string): string {
+    switch (fieldName) {
+        case "sex":
+            return "Sex";
+        case "participant_type":
+            return "ParticipantType";
+        case "condition":
+            return "DatasetCondition";
+        case "extraction_protocol":
+            return "DatasetExtractionProtocol";
+        case "read_type":
+            return "DatasetReadType";
+        case "dataset_type":
+            return "DatasetType";
+        default:
+            return "Sex";
+    }
+}
+
+const useTextStyles = makeStyles(theme => ({
+    textField: {
+        margin: theme.spacing(0.2),
+        width: "50%",
+    },
+}));
+
+/**
+ * A material-ui text field whose form changes depending on the type of field (date, long text, etc.)
+ */
+function EnhancedTextField({
+    field,
+    enums,
+    onEdit,
+}: {
+    field: Field;
+    enums: any;
+    onEdit: (fieldName: string | undefined, value: any) => void;
+}) {
+    const classes = useTextStyles();
+    const nullOption = (
+        <MenuItem value={""}>
+            <em>None</em>
+        </MenuItem>
+    );
+    if (!field.fieldName || !enums) return <></>;
+
+    // Props common to all variants
+    const textFieldProps: TextFieldProps = {
+        className: classes.textField,
+        margin: "dense",
+        label: field.title,
+        value: formatFieldValue(field.value),
+        required: nonNullableFields.includes(field.fieldName),
+        disabled: field.disableEdit,
+        onChange: (e: TextFieldEvent) => onEdit(field.fieldName, e.target.value), // default
+    };
+
+    // Props specific to each variant
+    if (enumFields.includes(field.fieldName)) {
+        // Value is chosen from a list
+        textFieldProps.select = true;
+        textFieldProps.onChange = (e: TextFieldEvent) => {
+            onEdit(field.fieldName, e.target.value === "" ? null : e.target.value);
+        };
+        textFieldProps.children = [
+            ...enums[getFieldInEnums(field.fieldName)].map((option: string) => (
+                <MenuItem key={option} value={option}>
+                    {option}
+                </MenuItem>
+            )),
+            !nonNullableFields.includes(field.fieldName) && nullOption,
+        ];
+    } else if (booleanFields.includes(field.fieldName)) {
+        // Value is a boolean or null
+        textFieldProps.select = true;
+        textFieldProps.onChange = (e: TextFieldEvent) => {
+            let val;
+            switch (e.target.value) {
+                case "No":
+                    val = false;
+                    break;
+                case "Yes":
+                    val = true;
+                    break;
+                default:
+                    val = null;
+                    break;
+            }
+            onEdit(field.fieldName, val);
+        };
+        textFieldProps.value = formatFieldValue(field.value, true);
+
+        const options = Object.values(PseudoBooleanReadableMap);
+        textFieldProps.children = [
+            ...options.map((option: string) => (
+                <MenuItem key={option} value={option}>
+                    {option}
+                </MenuItem>
+            )),
+        ];
+    } else if (multilineFields.includes(field.fieldName)) {
+        // Value is typed in, and can be really long (notes)
+        textFieldProps.multiline = true;
+        textFieldProps.rowsMax = 2;
+    } else if (dateFields.includes(field.fieldName)) {
+        // Value is a date string
+        textFieldProps.InputLabelProps = { shrink: true };
+        textFieldProps.type = "date";
+    } else {
+        // Value is a string (default)
+        textFieldProps.onChange = (e: TextFieldEvent) =>
+            onEdit(field.fieldName, e.target.value === "" ? null : e.target.value);
+    }
+
+    return <TextField {...textFieldProps} />;
+}
+
+const useStyles = makeStyles(theme => ({
+    box: {
+        padding: theme.spacing(0.5),
+    },
+}));
+
+export default function FieldDisplayEditable(props: {
+    field: Field;
+    editMode: boolean;
+    onEdit: (fieldName: string | undefined, value: any) => void;
+    enums: any;
+}) {
+    const classes = useStyles();
+
+    return (
+        <>
+            <Fade in={props.editMode}>
+                <Box hidden={!props.editMode}>
+                    <EnhancedTextField
+                        field={props.field}
+                        enums={props.enums}
+                        onEdit={props.onEdit}
+                    />
+                </Box>
+            </Fade>
+            <Fade in={!props.editMode}>
+                <Box className={classes.box} hidden={props.editMode}>
+                    <FieldDisplay
+                        title={props.field.title}
+                        value={props.field.value}
+                        bool={
+                            !!props.field.fieldName &&
+                            !!booleanFields.includes(props.field.fieldName)
+                        }
+                    />
+                </Box>
+            </Fade>
+        </>
+    );
+}

--- a/react/src/pages/utils/components/FieldDisplayEditable.tsx
+++ b/react/src/pages/utils/components/FieldDisplayEditable.tsx
@@ -59,15 +59,17 @@ function EnhancedTextField({
 }: {
     field: Field;
     enums: any;
-    onEdit: (fieldName: string | undefined, value: any) => void;
+    onEdit: (fieldName: string | undefined, value: boolean | string | null) => void;
 }) {
     const classes = useTextStyles();
     const nullOption = (
-        <MenuItem value={""}>
+        <MenuItem value={""} key="">
             <em>None</em>
         </MenuItem>
     );
     if (!field.fieldName || !enums) return <></>;
+
+    let children: React.ReactNode = [];
 
     // Props common to all variants
     const textFieldProps: TextFieldProps = {
@@ -87,7 +89,7 @@ function EnhancedTextField({
         textFieldProps.onChange = (e: TextFieldEvent) => {
             onEdit(field.fieldName, e.target.value === "" ? null : e.target.value);
         };
-        textFieldProps.children = [
+        children = [
             ...enums[getFieldInEnums(field.fieldName)].map((option: string) => (
                 <MenuItem key={option} value={option}>
                     {option}
@@ -116,7 +118,7 @@ function EnhancedTextField({
         textFieldProps.value = formatFieldValue(field.value, true);
 
         const options = Object.values(PseudoBooleanReadableMap);
-        textFieldProps.children = [
+        children = [
             ...options.map((option: string) => (
                 <MenuItem key={option} value={option}>
                     {option}
@@ -137,7 +139,7 @@ function EnhancedTextField({
             onEdit(field.fieldName, e.target.value === "" ? null : e.target.value);
     }
 
-    return <TextField {...textFieldProps} />;
+    return <TextField {...textFieldProps}>{children}</TextField>;
 }
 
 const useStyles = makeStyles(theme => ({

--- a/react/src/pages/utils/components/GridFieldsDisplay.tsx
+++ b/react/src/pages/utils/components/GridFieldsDisplay.tsx
@@ -3,16 +3,21 @@ import { Grid } from "@material-ui/core";
 import { Field } from "../typings";
 import FieldDisplayEditable from "./FieldDisplayEditable";
 
-const infoWidth = 6;
+// Yes, really
+type Width = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 /**
- * Display a collection of Fields in two columns in the specified order.
+ * Display a collection of editable fields. Number of columns can be specified.
+ *
+ * @param orderPriority How to display the fields (left-right first or top-down first)
+ * @param columnWidth The width of each column (out of 12, must be an integer)
  */
 export default function GridFieldsDisplay(props: {
     fields: Field[];
     editMode: boolean;
     onEdit: (fieldName: string | undefined, value: any) => void;
     orderPriority?: "left-right" | "top-down";
+    columnWidth?: Width;
 }) {
     const [enums, setEnums] = useState(undefined);
 
@@ -29,46 +34,65 @@ export default function GridFieldsDisplay(props: {
         });
     }, []);
 
-    let leftFields: Field[] = [];
-    let rightFields: Field[] = [];
-    const cap = Math.ceil(props.fields.length / 2);
+    const infoWidth = props.columnWidth || 6;
+    const numColumns = Math.floor(12 / infoWidth);
+
+    let fieldColumns: Field[][] = [...Array(numColumns)].map(() => []);
 
     if (props.orderPriority === "left-right") {
-        for (let i = 0; i < props.fields.length; i += 2) {
-            const j = i + 1;
-            leftFields.push(props.fields[i]);
-            if (j < props.fields.length) rightFields.push(props.fields[j]);
+        for (let i = 0; i < props.fields.length; i += numColumns) {
+            for (let j = 0; j < numColumns; j++) {
+                if (i + j < props.fields.length) fieldColumns[j].push(props.fields[i + j]);
+            }
         }
     } else {
-        for (let i = 0; i < cap; i++) {
-            const j = cap + i;
-            leftFields.push(props.fields[i]);
-            if (j < props.fields.length) rightFields.push(props.fields[j]);
+        const cap = Math.ceil(props.fields.length / numColumns);
+        for (let i = 0; i < numColumns; i++) {
+            for (let j = 0; j < cap; j++) {
+                if (i + j < props.fields.length) fieldColumns[i].push(props.fields[i + j]);
+            }
         }
     }
 
     return (
         <>
-            <Grid item xs={infoWidth}>
-                {leftFields.map(field => (
-                    <FieldDisplayEditable
-                        field={field}
-                        editMode={props.editMode}
-                        enums={enums}
-                        onEdit={props.onEdit}
-                    />
-                ))}
-            </Grid>
-            <Grid item xs={infoWidth}>
-                {rightFields.map(field => (
-                    <FieldDisplayEditable
-                        field={field}
-                        editMode={props.editMode}
-                        enums={enums}
-                        onEdit={props.onEdit}
-                    />
-                ))}
-            </Grid>
+            {fieldColumns.map(column => (
+                <Grid item xs={infoWidth}>
+                    {column.map(field => (
+                        <FieldDisplayEditable
+                            field={field}
+                            editMode={props.editMode}
+                            enums={enums}
+                            onEdit={props.onEdit}
+                        />
+                    ))}
+                </Grid>
+            ))}
         </>
     );
+
+    // return (
+    //     <>
+    //         <Grid item xs={infoWidth}>
+    //             {leftFields.map(field => (
+    //                 <FieldDisplayEditable
+    //                     field={field}
+    //                     editMode={props.editMode}
+    //                     enums={enums}
+    //                     onEdit={props.onEdit}
+    //                 />
+    //             ))}
+    //         </Grid>
+    //         <Grid item xs={infoWidth}>
+    //             {rightFields.map(field => (
+    //                 <FieldDisplayEditable
+    //                     field={field}
+    //                     editMode={props.editMode}
+    //                     enums={enums}
+    //                     onEdit={props.onEdit}
+    //                 />
+    //             ))}
+    //         </Grid>
+    //     </>
+    // );
 }

--- a/react/src/pages/utils/components/GridFieldsDisplay.tsx
+++ b/react/src/pages/utils/components/GridFieldsDisplay.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Grid } from "@material-ui/core";
 import { Field } from "../typings";
 import FieldDisplayEditable from "./FieldDisplayEditable";
 
-// Yes, really
+// Grids are very picky about their sizings
 type Width = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 /**
@@ -16,24 +16,10 @@ export default function GridFieldsDisplay(props: {
     fields: Field[];
     editMode: boolean;
     onEdit: (fieldName: string | undefined, value: any) => void;
+    enums: any;
     orderPriority?: "left-right" | "top-down";
     columnWidth?: Width;
 }) {
-    const [enums, setEnums] = useState(undefined);
-
-    useEffect(() => {
-        fetch("/api/enums").then(async response => {
-            if (response.ok) {
-                const enums = await response.json();
-                setEnums(enums);
-            } else {
-                console.error(
-                    `GET /api/enums failed with ${response.status}: ${response.statusText}`
-                );
-            }
-        });
-    }, []);
-
     const infoWidth = props.columnWidth || 6;
     const numColumns = Math.floor(12 / infoWidth);
 
@@ -64,7 +50,7 @@ export default function GridFieldsDisplay(props: {
                         <FieldDisplayEditable
                             field={field}
                             editMode={props.editMode}
-                            enums={enums}
+                            enums={props.enums}
                             onEdit={props.onEdit}
                         />
                     ))}
@@ -72,29 +58,4 @@ export default function GridFieldsDisplay(props: {
             ))}
         </>
     );
-
-    // return (
-    //     <>
-    //         <Grid item xs={infoWidth}>
-    //             {leftFields.map(field => (
-    //                 <FieldDisplayEditable
-    //                     field={field}
-    //                     editMode={props.editMode}
-    //                     enums={enums}
-    //                     onEdit={props.onEdit}
-    //                 />
-    //             ))}
-    //         </Grid>
-    //         <Grid item xs={infoWidth}>
-    //             {rightFields.map(field => (
-    //                 <FieldDisplayEditable
-    //                     field={field}
-    //                     editMode={props.editMode}
-    //                     enums={enums}
-    //                     onEdit={props.onEdit}
-    //                 />
-    //             ))}
-    //         </Grid>
-    //     </>
-    // );
 }

--- a/react/src/pages/utils/components/GridFieldsDisplay.tsx
+++ b/react/src/pages/utils/components/GridFieldsDisplay.tsx
@@ -42,14 +42,16 @@ export default function GridFieldsDisplay(props: {
     if (props.orderPriority === "left-right") {
         for (let i = 0; i < props.fields.length; i += numColumns) {
             for (let j = 0; j < numColumns; j++) {
-                if (i + j < props.fields.length) fieldColumns[j].push(props.fields[i + j]);
+                const index = i + j;
+                if (index < props.fields.length) fieldColumns[j].push(props.fields[index]);
             }
         }
     } else {
         const cap = Math.ceil(props.fields.length / numColumns);
         for (let i = 0; i < numColumns; i++) {
             for (let j = 0; j < cap; j++) {
-                if (i + j < props.fields.length) fieldColumns[i].push(props.fields[i + j]);
+                const index = j + cap * i;
+                if (index < props.fields.length) fieldColumns[i].push(props.fields[index]);
             }
         }
     }

--- a/react/src/pages/utils/components/GridFieldsDisplay.tsx
+++ b/react/src/pages/utils/components/GridFieldsDisplay.tsx
@@ -4,12 +4,12 @@ import { Field } from "../typings";
 import FieldDisplayEditable from "./FieldDisplayEditable";
 
 // Grids are very picky about what sizes are allowed
-type Width = Exclude<GridProps["xs"], boolean | "auto" | undefined>;
+type Width = Exclude<GridProps["xs"], boolean | "auto">;
 
 /**
- * Display a collection of editable fields. Number of columns can be specified.
+ * Display a collection of editable fields. Column width can be specified.
  *
- * @param orderPriority How to display the fields (left-right first or top-down first)
+ * @param orderPriority How to display the fields (default to top-down first)
  * @param columnWidth The width of each column (out of 12, must be an integer)
  */
 export default function GridFieldsDisplay(props: {
@@ -23,13 +23,14 @@ export default function GridFieldsDisplay(props: {
     const infoWidth = props.columnWidth || 6;
     const numColumns = Math.floor(12 / infoWidth);
 
-    let fieldColumns: Field[][] = [...Array(numColumns)].map(() => []);
+    let fieldColumns: { field: Field; key: string }[][] = Array(numColumns).map(() => []);
 
     if (props.orderPriority === "left-right") {
         for (let i = 0; i < props.fields.length; i += numColumns) {
             for (let j = 0; j < numColumns; j++) {
                 const index = i + j;
-                if (index < props.fields.length) fieldColumns[j].push(props.fields[index]);
+                if (index < props.fields.length)
+                    fieldColumns[j].push({ field: props.fields[index], key: `field-${index}` });
             }
         }
     } else {
@@ -37,7 +38,8 @@ export default function GridFieldsDisplay(props: {
         for (let i = 0; i < numColumns; i++) {
             for (let j = 0; j < cap; j++) {
                 const index = j + cap * i;
-                if (index < props.fields.length) fieldColumns[i].push(props.fields[index]);
+                if (index < props.fields.length)
+                    fieldColumns[i].push({ field: props.fields[index], key: `field-${index}` });
             }
         }
     }
@@ -45,13 +47,14 @@ export default function GridFieldsDisplay(props: {
     return (
         <>
             {fieldColumns.map(column => (
-                <Grid item xs={infoWidth}>
-                    {column.map(field => (
+                <Grid item xs={infoWidth} key={`column-${column[0].key}`}>
+                    {column.map(value => (
                         <FieldDisplayEditable
-                            field={field}
+                            field={value.field}
                             editMode={props.editMode}
                             enums={props.enums}
                             onEdit={props.onEdit}
+                            key={value.key}
                         />
                     ))}
                 </Grid>

--- a/react/src/pages/utils/components/GridFieldsDisplay.tsx
+++ b/react/src/pages/utils/components/GridFieldsDisplay.tsx
@@ -23,7 +23,7 @@ export default function GridFieldsDisplay(props: {
     const infoWidth = props.columnWidth || 6;
     const numColumns = Math.floor(12 / infoWidth);
 
-    let fieldColumns: { field: Field; key: string }[][] = Array(numColumns).map(() => []);
+    let fieldColumns: { field: Field; key: string }[][] = [...Array(numColumns)].map(() => []);
 
     if (props.orderPriority === "left-right") {
         for (let i = 0; i < props.fields.length; i += numColumns) {
@@ -46,8 +46,8 @@ export default function GridFieldsDisplay(props: {
 
     return (
         <>
-            {fieldColumns.map(column => (
-                <Grid item xs={infoWidth} key={`column-${column[0].key}`}>
+            {fieldColumns.map((column, colIndex) => (
+                <Grid item xs={infoWidth} key={`column-${colIndex}`}>
                     {column.map(value => (
                         <FieldDisplayEditable
                             field={value.field}

--- a/react/src/pages/utils/components/GridFieldsDisplay.tsx
+++ b/react/src/pages/utils/components/GridFieldsDisplay.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { Grid } from "@material-ui/core";
+import { Grid, GridProps } from "@material-ui/core";
 import { Field } from "../typings";
 import FieldDisplayEditable from "./FieldDisplayEditable";
 
-// Grids are very picky about their sizings
-type Width = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+// Grids are very picky about what sizes are allowed
+type Width = Exclude<GridProps["xs"], boolean | "auto" | undefined>;
 
 /**
  * Display a collection of editable fields. Number of columns can be specified.

--- a/react/src/pages/utils/components/GridFieldsDisplay.tsx
+++ b/react/src/pages/utils/components/GridFieldsDisplay.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from "react";
+import { Grid } from "@material-ui/core";
+import { Field } from "../typings";
+import FieldDisplayEditable from "./FieldDisplayEditable";
+
+const infoWidth = 6;
+
+/**
+ * Display a collection of Fields in two columns in the specified order.
+ */
+export default function GridFieldsDisplay(props: {
+    fields: Field[];
+    editMode: boolean;
+    onEdit: (fieldName: string | undefined, value: any) => void;
+    orderPriority?: "left-right" | "top-down";
+}) {
+    const [enums, setEnums] = useState(undefined);
+
+    useEffect(() => {
+        fetch("/api/enums").then(async response => {
+            if (response.ok) {
+                const enums = await response.json();
+                setEnums(enums);
+            } else {
+                console.error(
+                    `GET /api/enums failed with ${response.status}: ${response.statusText}`
+                );
+            }
+        });
+    }, []);
+
+    let leftFields: Field[] = [];
+    let rightFields: Field[] = [];
+    const cap = Math.ceil(props.fields.length / 2);
+
+    if (props.orderPriority === "left-right") {
+        for (let i = 0; i < props.fields.length; i += 2) {
+            const j = i + 1;
+            leftFields.push(props.fields[i]);
+            if (j < props.fields.length) rightFields.push(props.fields[j]);
+        }
+    } else {
+        for (let i = 0; i < cap; i++) {
+            const j = cap + i;
+            leftFields.push(props.fields[i]);
+            if (j < props.fields.length) rightFields.push(props.fields[j]);
+        }
+    }
+
+    return (
+        <>
+            <Grid item xs={infoWidth}>
+                {leftFields.map(field => (
+                    <FieldDisplayEditable
+                        field={field}
+                        editMode={props.editMode}
+                        enums={enums}
+                        onEdit={props.onEdit}
+                    />
+                ))}
+            </Grid>
+            <Grid item xs={infoWidth}>
+                {rightFields.map(field => (
+                    <FieldDisplayEditable
+                        field={field}
+                        editMode={props.editMode}
+                        enums={enums}
+                        onEdit={props.onEdit}
+                    />
+                ))}
+            </Grid>
+        </>
+    );
+}

--- a/react/src/pages/utils/components/InfoList.tsx
+++ b/react/src/pages/utils/components/InfoList.tsx
@@ -34,6 +34,7 @@ const useStyles = makeStyles(theme => ({
 
 export default function InfoList(props: {
     infoList: Info[];
+    enums: any;
     title?: string;
     icon: JSX.Element;
     linkPath?: string;
@@ -72,6 +73,7 @@ export default function InfoList(props: {
                             <Box className={classes.box}>
                                 <DetailSection
                                     fields={info.fields}
+                                    enums={props.enums}
                                     collapsibleFields={info.collapsibleFields}
                                 />
                                 {props.linkPath && info.identifier && (

--- a/react/src/pages/utils/functions.tsx
+++ b/react/src/pages/utils/functions.tsx
@@ -12,6 +12,7 @@ import {
     Field,
     DataEntryRow,
     PseudoBoolean,
+    PseudoBooleanReadableMap,
 } from "./typings";
 
 export function countArray(items: string[]) {
@@ -343,4 +344,17 @@ export function rowDiff<T>(newRow: T, oldRow: T | undefined): Partial<T> {
         }
         return { ...diffRow };
     }
+}
+
+/**
+ * Formats the provided FieldDisplay value as a user-readable string.
+ */
+export function formatFieldValue(value: FieldDisplayValueType, nullUnknown: boolean = false) {
+    let val = value;
+    if (Array.isArray(value)) val = value.join(", ");
+    else if (value === null || value === undefined)
+        nullUnknown ? (val = PseudoBooleanReadableMap[("" + value) as PseudoBoolean]) : (val = "");
+    else if (typeof value === "boolean")
+        val = PseudoBooleanReadableMap[("" + value) as PseudoBoolean];
+    return val;
 }

--- a/react/src/pages/utils/functions.tsx
+++ b/react/src/pages/utils/functions.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import {
     Counts,
     KeyValue,

--- a/react/src/pages/utils/functions.tsx
+++ b/react/src/pages/utils/functions.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import {
     Counts,
     KeyValue,


### PR DESCRIPTION
- Components associated with `DetailSection` are now separated into different files and broken down further.
  - `GridFieldsDisplay` moved to separate file.
  - editable `TextField` overwrite in `DetailSection` moved to file with `FieldDisplayEditable`.
  - `FieldDisplay` moved to separate file.
- Above components updated to take `enums` as props, as opposed to fetching enums for each element that needs them. May be worth looking into making a custom "useEnums" hook in the future.
- State management should be more clear now 
  - Dialog holds the state of the selected 'record' (dataset, analysis, etc.).
  - Child elements are passed props with this state and a way to update it. 
  - `DetailSection` uses state to track edit mode changes that may be discarded.