### PR TITLE
Flask & React: update POST /api/users, user creation form

### DIFF
--- a/flask/app/config.py
+++ b/flask/app/config.py
@@ -23,4 +23,3 @@ class Config(object):
     )
     MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE")
     TESTING = False
-    LOGIN_DISABLED = True

--- a/flask/app/config.py
+++ b/flask/app/config.py
@@ -23,3 +23,4 @@ class Config(object):
     )
     MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "AKIAIOSFODNN7EXAMPLE")
     TESTING = False
+    LOGIN_DISABLED = True

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -1,5 +1,4 @@
 import inspect
-import json
 from dataclasses import asdict
 from datetime import datetime
 from enum import Enum
@@ -8,14 +7,11 @@ from io import StringIO
 from typing import Any, Callable, Dict, List, Union
 
 import pandas as pd
+from flask import abort, current_app as app, jsonify, Response, request
 from flask_login import current_user, login_required, login_user, logout_user
 from sqlalchemy import exc
 from sqlalchemy.orm import aliased, contains_eager, joinedload
 from werkzeug.exceptions import HTTPException
-
-from flask import Response, abort
-from flask import current_app as app
-from flask import jsonify, request
 
 from . import db, login, models
 

--- a/flask/app/users.py
+++ b/flask/app/users.py
@@ -1,12 +1,14 @@
 import os
 
-from flask import current_app as app, jsonify, request
 from flask_login import current_user, login_required
 from sqlalchemy.orm import joinedload
 
+from flask import current_app as app
+from flask import jsonify, request
+
 from . import db, models
-from .routes import check_admin, transaction_or_abort
 from .madmin import MinioAdmin
+from .routes import check_admin, transaction_or_abort
 
 
 @app.route("/api/users", methods=["GET"])
@@ -29,6 +31,21 @@ def list_users():
     )
 
 
+def jsonify_user(user: models.User):
+    return jsonify(
+        {
+            "username": user.username,
+            "email": user.email,
+            "is_admin": user.is_admin,
+            "last_login": user.last_login,
+            "deactivated": user.deactivated,
+            "groups": [group.group_code for group in user.groups],
+            "minio_access_key": user.minio_access_key,
+            "minio_secret_key": user.minio_secret_key,
+        }
+    )
+
+
 @app.route("/api/users/<string:username>", methods=["GET"])
 @login_required
 def get_user(username: str):
@@ -45,18 +62,33 @@ def get_user(username: str):
         .first_or_404()
     )
 
-    return jsonify(
-        {
-            "username": user.username,
-            "email": user.email,
-            "is_admin": user.is_admin,
-            "last_login": user.last_login,
-            "deactivated": user.deactivated,
-            "groups": [group.group_code for group in user.groups],
-            "minio_access_key": user.minio_access_key,
-            "minio_secret_key": user.minio_secret_key,
-        }
+    return jsonify_user(user)
+
+
+def reset_minio_credentials(user: models.User) -> None:
+    minio_admin = MinioAdmin(
+        endpoint=app.config["MINIO_ENDPOINT"],
+        access_key=app.config["MINIO_ACCESS_KEY"],
+        secret_key=app.config["MINIO_SECRET_KEY"],
     )
+    if user.minio_access_key:
+        try:
+            minio_admin.remove_user(user.minio_access_key)
+        except RuntimeError as err:
+            app.logger.warning(err.args[0])
+    # Generate cryptographically random pair
+    access_key = os.urandom(8).hex()  # 16 ASCII characters
+    secret_key = os.urandom(16).hex()  # 32 ASCII characters
+    # Probability of conflict is negligible and not considered
+    minio_admin.add_user(access_key, secret_key)
+    for group in user.groups:
+        # MinIO requires a user to exist to create the group so the access policy
+        # might not be set on a group if this is the first user to be added, however
+        # we can guarantee from POST /api/groups that the policy exists in MinIO
+        minio_admin.group_add(group.group_code, access_key)
+        minio_admin.set_policy(group.group_code, group=group.group_code)
+    user.minio_access_key = access_key
+    user.minio_secret_key = secret_key
 
 
 @app.route("/api/users/<string:username>", methods=["POST"])
@@ -68,43 +100,63 @@ def reset_minio_user(username: str):
         and username != current_user.username
     ):
         return "Unauthorized", 401
-
     if not request.json:
         return "Request body must be JSON", 415
-
     user = (
         models.User.query.options(joinedload(models.User.groups))
         .filter(models.User.username == username)
         .first_or_404()
     )
-
-    minio_admin = MinioAdmin(
-        endpoint=app.config["MINIO_ENDPOINT"],
-        access_key=app.config["MINIO_ACCESS_KEY"],
-        secret_key=app.config["MINIO_SECRET_KEY"],
+    # TODO: maybe rate limit this API because generating these is expensive
+    reset_minio_credentials(user)
+    transaction_or_abort(db.session.commit)
+    return jsonify(
+        {
+            "minio_access_key": user.minio_access_key,
+            "minio_secret_key": user.minio_secret_key,
+        }
     )
 
-    if user.minio_access_key:
-        try:
-            minio_admin.remove_user(user.minio_access_key)
-        except RuntimeError as err:
-            app.logger.warning(err.args[0])
 
-    # Generate cryptographically random pair
-    # TODO: maybe rate limit this API because generating these is expensive
-    access_key = os.urandom(8).hex()  # 16 ASCII characters
-    secret_key = os.urandom(16).hex()  # 32 ASCII characters
-    # Probability of conflict is negligible and not considered
-    minio_admin.add_user(access_key, secret_key)
-    for group in user.groups:
-        # MinIO requires a user to exist to create the group so the access policy
-        # might not be set on a group if this is the first user to be added, however
-        # we can guarantee from POST /api/groups that the policy exists in MinIO
-        minio_admin.group_add(group.group_code, access_key)
-        minio_admin.set_policy(group.group_code, group=group.group_code)
+@app.route("/api/users", methods=["POST"])
+@login_required
+@check_admin
+def create_user():
+    if not request.json:
+        return "Request body must be JSON", 415
 
-    user.minio_access_key = access_key
-    user.minio_secret_key = secret_key
-    transaction_or_abort(db.session.commit)
+    if (
+        "username" not in request.json
+        or "password" not in request.json
+        or "email" not in request.json
+    ):
+        return "Missing fields", 400
 
-    return jsonify({"minio_access_key": access_key, "minio_secret_key": secret_key})
+    user = models.User.query.filter_by(username=request.json["username"]).first()
+    if user is not None:
+        return "User already exists", 422, {"location": f"/api/users/{user.username}"}
+
+    user = models.User(
+        username=request.json["username"],
+        email=request.json["email"],
+        is_admin=request.json.get("is_admin"),
+    )
+    user.set_password(request.json["password"])
+
+    requested_groups = request.json.get("groups")
+    if requested_groups:
+        groups = models.Group.query.filter(
+            models.Group.group_code.in_(requested_groups)
+        ).all()
+        if len(requested_groups) != len(groups):
+            return "Invalid group code provided", 404
+        user.groups += groups
+
+    reset_minio_credentials(user)
+    db.session.add(user)
+    try:
+        db.session.commit()
+        return jsonify_user(user), 201, {"location": f"/api/users/{user.username}"}
+    except:
+        db.session.rollback()
+        return "Server error", 500

--- a/flask/app/users.py
+++ b/flask/app/users.py
@@ -138,12 +138,12 @@ def create_user():
     if not valid_strings(request.json, "username", "email", "password"):
         return "Missing fields", 400
 
-    user = models.User.query.filter_by(username=request.json["username"]).first()
+    user = models.User.query.filter(
+        (models.User.username == request.json["username"])
+        | (models.User.email == request.json["email"])
+    ).first()
     if user is not None:
         return "User already exists", 422, {"location": f"/api/users/{user.username}"}
-    user = models.User.query.filter_by(email=request.json["email"]).first()
-    if user is not None:
-        return "Email already used", 422, {"location": f"/api/users/{user.username}"}
 
     user = models.User(
         username=request.json["username"],

--- a/flask/app/users.py
+++ b/flask/app/users.py
@@ -161,7 +161,12 @@ def create_user():
         | (models.User.email == request.json["email"])
     ).first()
     if user is not None:
-        return "User already exists", 422, {"location": f"/api/users/{user.username}"}
+        # TODO: integrate with #219
+        if user.username == request.json["username"]:
+            error = {"error": "existingUser", "message": "User already exists."}
+        else:
+            error = {"error": "existingEmail", "message": "Email already in use."}
+        return jsonify(error), 422, {"location": f"/api/users/{user.username}"}
 
     user = models.User(
         username=request.json["username"],

--- a/flask/app/users.py
+++ b/flask/app/users.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any, Dict
 
 from flask_login import current_user, login_required
 from sqlalchemy.orm import joinedload
@@ -118,6 +119,15 @@ def reset_minio_user(username: str):
     )
 
 
+def valid_strings(body: Dict[str, Any], *keys: str) -> bool:
+    return all(
+        map(
+            lambda key: key in body and isinstance(body[key], str) and len(body[key]),
+            keys,
+        )
+    )
+
+
 @app.route("/api/users", methods=["POST"])
 @login_required
 @check_admin
@@ -125,11 +135,7 @@ def create_user():
     if not request.json:
         return "Request body must be JSON", 415
 
-    if (
-        "username" not in request.json
-        or "password" not in request.json
-        or "email" not in request.json
-    ):
+    if not valid_strings(request.json, "username", "email", "password"):
         return "Missing fields", 400
 
     user = models.User.query.filter_by(username=request.json["username"]).first()

--- a/flask/tests/conftest.py
+++ b/flask/tests/conftest.py
@@ -1,4 +1,6 @@
-import os, pytest
+import os
+
+import pytest
 from app import create_app, db
 from app.config import Config
 from app.models import *
@@ -223,12 +225,13 @@ def test_database(client):
 
 @pytest.fixture
 def login_as(client):
-    def login(identity: str) -> None:
+    def login(username: str, password: str = None) -> None:
+        password = password or username
         client.post("/api/logout", json={"useless": "why"})
         assert (
             client.post(
                 "/api/login",
-                json={"username": identity, "password": identity},
+                json={"username": username, "password": password},
                 follow_redirects=True,
             ).status_code
             == 200

--- a/flask/tests/test_users.py
+++ b/flask/tests/test_users.py
@@ -233,4 +233,7 @@ def test_create_conflicting_user(test_database, client, login_as):
         {"username": "sapphire", "email": "test@sickkids.ca", "password": "fail"},
     ]
     for user in users:
-        assert client.post("/api/users", json=user).status_code == 422
+        response = client.post("/api/users", json=user)
+        assert response.status_code == 422
+        error = response.get_json()
+        assert "error" in error and "message" in error

--- a/flask/tests/test_users.py
+++ b/flask/tests/test_users.py
@@ -202,3 +202,26 @@ def test_create_admin(test_database, minio_policy, client, login_as):
         login_as,
     )
     assert client.get("/api/users").status_code == 200
+
+
+def test_create_blank_user(test_database, client, login_as):
+    login_as("admin")
+    # Some defensive checks
+    assert (
+        client.post(
+            "/api/users", json={"username": "", "email": "", "password": ""}
+        ).status_code
+        == 400
+    )
+    assert (
+        client.post(
+            "/api/users", json={"username": "blank", "email": "blank", "password": ""}
+        ).status_code
+        == 400
+    )
+    assert (
+        client.post(
+            "/api/users", json={"username": "", "email": "blank", "password": "blank"}
+        ).status_code
+        == 400
+    )

--- a/flask/tests/test_users.py
+++ b/flask/tests/test_users.py
@@ -1,6 +1,6 @@
 import pytest
-from conftest import TestConfig
 from app.madmin import MinioAdmin, readwrite_buckets_policy
+from conftest import TestConfig
 
 # Common response values between list and individual get endpoints
 expected_admin_common = {
@@ -141,3 +141,64 @@ def test_reset_minio_user(test_database, minio_policy, client, login_as):
     assert client.post("/api/users/admin").status_code == 401
 
     assert_reset("user", client)
+
+
+def assert_new_user(body, client, login_as):
+    response = client.post("/api/users", json=body)
+    assert response.status_code == 201
+    user = response.get_json()
+    assert response.location.endswith(f"/api/users/{user['username']}")
+    assert user["username"] == body["username"]
+    assert user["email"] == body["email"]
+    assert "password" not in user
+    assert user["is_admin"] == body.get("is_admin", False)
+    assert user["groups"] == body.get("groups", [])
+    assert isinstance(user["minio_access_key"], str)
+    assert isinstance(user["minio_secret_key"], str)
+    login_as(body["username"], body["password"])
+
+
+def test_create_user(test_database, client, login_as):
+    assert client.post("/api/users").status_code == 401
+    login_as("user")
+    assert client.post("/api/users").status_code == 401
+    assert client.post("/api/users", json={"xml": "bad"}).status_code == 401
+
+    login_as("admin")
+    assert client.post("/api/users").status_code == 415
+    assert client.post("/api/users", json={"xml": "bad"}).status_code == 400
+    assert client.post("/api/users", json={"username": "dormammu"}).status_code == 400
+    assert (
+        client.post(
+            "/api/users",
+            json={"username": "dormammu", "password": "I've come to bargain"},
+        ).status_code
+        == 400
+    )
+
+    assert_new_user(
+        {
+            "username": "dormammu",
+            "password": "I've come to bargain",
+            "email": "stephen.strange@agamotto.org",
+        },
+        client,
+        login_as,
+    )
+    assert client.get("/api/users").status_code == 401
+
+
+def test_create_admin(test_database, minio_policy, client, login_as):
+    login_as("admin")
+    assert_new_user(
+        {
+            "username": "vaccine",
+            "password": "covid-19",
+            "email": "mrna@example.org",
+            "is_admin": True,
+            "groups": ["ach"],
+        },
+        client,
+        login_as,
+    )
+    assert client.get("/api/users").status_code == 200

--- a/flask/tests/test_users.py
+++ b/flask/tests/test_users.py
@@ -34,6 +34,11 @@ def minio_policy():
         madmin.remove_policy("ach")
     except:
         pass
+    for user in madmin.list_users():
+        try:
+            madmin.remove_user(user["accessKey"])
+        except:
+            pass
 
 
 def test_list_users(test_database, client, login_as):

--- a/flask/tests/test_users.py
+++ b/flask/tests/test_users.py
@@ -225,3 +225,15 @@ def test_create_blank_user(test_database, client, login_as):
         ).status_code
         == 400
     )
+
+
+def test_create_conflicting_user(test_database, client, login_as):
+    login_as("admin")
+    users = [
+        {"username": "admin", "email": "notchecked", "password": "fail"},
+        {"username": "user", "email": "notchecked", "password": "fail"},
+        {"username": "adamant", "email": "noreply@sickkids.ca", "password": "fail"},
+        {"username": "sapphire", "email": "test@sickkids.ca", "password": "fail"},
+    ]
+    for user in users:
+        assert client.post("/api/users", json=user).status_code == 422

--- a/flask/tests/test_users.py
+++ b/flask/tests/test_users.py
@@ -211,32 +211,24 @@ def test_create_admin(test_database, minio_policy, client, login_as):
 
 def test_create_blank_user(test_database, client, login_as):
     login_as("admin")
-    # Some defensive checks
-    assert (
-        client.post(
-            "/api/users", json={"username": "", "email": "", "password": ""}
-        ).status_code
-        == 400
-    )
-    assert (
-        client.post(
-            "/api/users", json={"username": "blank", "email": "blank", "password": ""}
-        ).status_code
-        == 400
-    )
-    assert (
-        client.post(
-            "/api/users", json={"username": "", "email": "blank", "password": "blank"}
-        ).status_code
-        == 400
-    )
+    # Some defensive length checks
+    users = [
+        {"username": "", "email": "", "password": ""},
+        {"username": "blank", "email": "blank@example.ca", "password": ""},
+        {"username": "", "email": "blank@example.ca", "password": "blank"},
+        {"username": "a" * 31, "email": "blank@example.ca", "password": "toolong"},
+        {"username": "aaaaa", "email": "a" * 200 + "@f.ff", "password": "toolong"},
+        {"username": "aaaaa", "email": "localhost", "password": "notanemail"},
+    ]
+    for user in users:
+        assert client.post("/api/users", json=user).status_code == 400
 
 
 def test_create_conflicting_user(test_database, client, login_as):
     login_as("admin")
     users = [
-        {"username": "admin", "email": "notchecked", "password": "fail"},
-        {"username": "user", "email": "notchecked", "password": "fail"},
+        {"username": "admin", "email": "unused@example.ca", "password": "fail"},
+        {"username": "user", "email": "unused@example.ca", "password": "fail"},
         {"username": "adamant", "email": "noreply@sickkids.ca", "password": "fail"},
         {"username": "sapphire", "email": "test@sickkids.ca", "password": "fail"},
     ]

--- a/react/src/Admin/components/CreateUserModal.tsx
+++ b/react/src/Admin/components/CreateUserModal.tsx
@@ -26,7 +26,13 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-function ErrorText(props: { id: string; errorCode: number }) {
+interface ErrorTextProps {
+    id: string;
+    errorCode: number;
+    details: { error: string; message: string };
+}
+
+function ErrorText(props: ErrorTextProps) {
     switch (props.errorCode) {
         case 0:
             return <></>;
@@ -45,7 +51,7 @@ function ErrorText(props: { id: string; errorCode: number }) {
         case 422:
             return (
                 <DialogContentText id={props.id} color="secondary">
-                    Username or email already in use.
+                    {props.details.message}
                 </DialogContentText>
             );
         default:
@@ -66,6 +72,7 @@ export default function CreateUserModal(props: CreateUserModalProps) {
     const [confirmPassword, setConfirmPassword] = useState("");
     const [submitting, setSubmitting] = useState(false);
     const [errorCode, setErrorCode] = useState(0);
+    const [errorDetails, setErrorDetails] = useState({ error: "", message: "" });
 
     async function submit(e: React.FormEvent) {
         setSubmitting(true);
@@ -93,6 +100,11 @@ export default function CreateUserModal(props: CreateUserModalProps) {
         } else {
             setErrorCode(response.status);
         }
+        if (response.status === 422) {
+            setErrorDetails(await response.json());
+        } else {
+            setErrorDetails({ error: "", message: "" });
+        }
         setSubmitting(false);
     }
 
@@ -113,7 +125,11 @@ export default function CreateUserModal(props: CreateUserModalProps) {
         >
             <DialogTitle id={`${props.id}-title`}>New user</DialogTitle>
             <DialogContent>
-                <ErrorText id={`${props.id}-description`} errorCode={errorCode} />
+                <ErrorText
+                    id={`${props.id}-description`}
+                    errorCode={errorCode}
+                    details={errorDetails}
+                />
                 <TextField
                     required
                     autoFocus

--- a/react/src/Admin/components/CreateUserModal.tsx
+++ b/react/src/Admin/components/CreateUserModal.tsx
@@ -30,6 +30,12 @@ function ErrorText(props: { id: string; errorCode: number }) {
     switch (props.errorCode) {
         case 0:
             return <></>;
+        case 400:
+            return (
+                <DialogContentText id={props.id} color="secondary">
+                    Username or email too long, bad email, or other invalid input.
+                </DialogContentText>
+            );
         case 404:
             return (
                 <DialogContentText id={props.id} color="secondary">
@@ -43,7 +49,7 @@ function ErrorText(props: { id: string; errorCode: number }) {
                 </DialogContentText>
             );
         default:
-            // 500 and the 400s and 415s that shouldn't happen
+            // 500 and the 415s that shouldn't happen
             return (
                 <DialogContentText id={props.id} color="secondary">
                     Something went wrong. Please try again later.

--- a/react/src/Admin/components/CreateUserModal.tsx
+++ b/react/src/Admin/components/CreateUserModal.tsx
@@ -69,6 +69,10 @@ export default function CreateUserModal(props: CreateUserModalProps) {
         );
     }
 
+    const passwordsDiffer = password !== confirmPassword;
+    const passwordErrorText = passwordsDiffer && "Passwords do not match.";
+    const submittable = username && email && password && !passwordsDiffer;
+
     return (
         <Dialog
             open={props.open}
@@ -87,7 +91,7 @@ export default function CreateUserModal(props: CreateUserModalProps) {
                     fullWidth
                     margin="dense"
                     variant="filled"
-                    label="Username (minimum 4 characters)"
+                    label="Username"
                     value={username}
                     onChange={e => setUsername(e.target.value)}
                 />
@@ -118,10 +122,12 @@ export default function CreateUserModal(props: CreateUserModalProps) {
                     fullWidth
                     margin="dense"
                     variant="filled"
-                    label="Password (minimum 4 characters)"
+                    label="Password"
                     type="password"
                     value={password}
                     onChange={e => setPassword(e.target.value)}
+                    error={passwordsDiffer}
+                    helperText={passwordErrorText}
                 />
                 <TextField
                     required
@@ -133,13 +139,21 @@ export default function CreateUserModal(props: CreateUserModalProps) {
                     type="password"
                     value={confirmPassword}
                     onChange={e => setConfirmPassword(e.target.value)}
+                    error={passwordsDiffer}
+                    helperText={passwordErrorText}
                 />
             </DialogContent>
             <DialogActions>
                 <Button onClick={props.onClose} color="default" variant="outlined">
                     Cancel
                 </Button>
-                <Button type="submit" onClick={submit} color="primary" variant="contained">
+                <Button
+                    type="submit"
+                    onClick={submit}
+                    disabled={!submittable}
+                    color="primary"
+                    variant="contained"
+                >
                     Create
                 </Button>
             </DialogActions>

--- a/react/src/Admin/components/UserList.tsx
+++ b/react/src/Admin/components/UserList.tsx
@@ -106,7 +106,9 @@ export default function UserList() {
                 onSuccess={user => {
                     dispatch({ type: "add", payload: user });
                     setOpenNewUser(false);
-                    enqueueSnackbar(`New user ${user.username} created successfully`);
+                    enqueueSnackbar(`New user "${user.username}" created successfully`, {
+                        variant: "success",
+                    });
                 }}
             />
             <Toolbar component={Paper} className={classes.toolbar}>


### PR DESCRIPTION
Now accepts admin status and groups, creates a MinIO identity, and return response more closely conforms with REST expectations.
Add conflicting checks for already-used usernames, emails. (Basic idea for #219)
Add defensive checks for blank usernames, emails, passwords.
Move password matching to frontend.
Refactor frontend user creation error handling, use wait cursor on submit, prevent multiple submission and submitting before finishing filling out the form
Use success variant snackbar.

#193 