### PR TITLE
React: Hide admin pages and dataset delete

### DIFF
--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -49,7 +49,13 @@ def login():
                 "Failed to updated last_login for %s", current_user.username
             )
 
-        return jsonify({"username": current_user.username, "last_login": last_login})
+        return jsonify(
+            {
+                "username": current_user.username,
+                "last_login": last_login,
+                "is_admin": current_user.is_admin,
+            }
+        )
 
     body = request.json
     if not body or "username" not in body or "password" not in body:
@@ -68,7 +74,13 @@ def login():
         app.logger.warning("Failed to updated last_login for %s", user.username)
 
     login_user(user)
-    return jsonify({"username": user.username, "last_login": last_login})
+    return jsonify(
+        {
+            "username": user.username,
+            "last_login": last_login,
+            "is_admin": current_user.is_admin,
+        }
+    )
 
 
 @app.route("/api/logout", methods=["POST"])

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -73,6 +73,7 @@ function BaseApp(props: { darkMode: boolean; toggleDarkMode: () => void }) {
                 setAuthenticated={setAuthenticated}
                 setLastLoginTime={setLastLoginTime}
                 setGlobalUsername={setUsername}
+                setIsAdmin={setIsAdmin}
             />
         );
     }

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -35,7 +35,7 @@ function BaseApp(props: { darkMode: boolean; toggleDarkMode: () => void }) {
                 const loginInfo = await result.json();
                 setUsername(loginInfo.username);
                 setLastLoginTime(loginInfo.last_login);
-                setIsAdmin(loginInfo.is_admin)
+                setIsAdmin(loginInfo.is_admin);
             }
             setAuthenticated(result.ok);
         })();

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -15,6 +15,7 @@ function BaseApp(props: { darkMode: boolean; toggleDarkMode: () => void }) {
     const [authenticated, setAuthenticated] = useState<boolean | null>(null);
     const [username, setUsername] = useState("");
     const [lastLoginTime, setLastLoginTime] = useState("");
+    const [isAdmin, setIsAdmin] = useState(false);
 
     async function signout() {
         const result = await fetch("/api/logout", {
@@ -34,6 +35,7 @@ function BaseApp(props: { darkMode: boolean; toggleDarkMode: () => void }) {
                 const loginInfo = await result.json();
                 setUsername(loginInfo.username);
                 setLastLoginTime(loginInfo.last_login);
+                setIsAdmin(loginInfo.is_admin)
             }
             setAuthenticated(result.ok);
         })();
@@ -61,6 +63,7 @@ function BaseApp(props: { darkMode: boolean; toggleDarkMode: () => void }) {
                     lastLoginTime={lastLoginTime}
                     darkMode={props.darkMode}
                     toggleDarkMode={props.toggleDarkMode}
+                    isAdmin={isAdmin}
                 />
             </SnackbarProvider>
         );

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -23,7 +23,11 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-export default function DatasetTable() {
+interface DatasetTableProps {
+    isAdmin: boolean;
+}
+
+export default function DatasetTable({ isAdmin }: DatasetTableProps) {
     const classes = useStyles();
     const [showRunner, setRunner] = useState(false);
     const [selectedDatasets, setSelectedDatasets] = useState<Dataset[]>([]);
@@ -271,6 +275,7 @@ export default function DatasetTable() {
                     {
                         tooltip: "Delete selected datasets",
                         icon: Delete,
+                        hidden: !isAdmin,
                         position: "toolbarOnSelect",
                         onClick: (evt, data) => {
                             const sampleString = (data as Dataset[])
@@ -302,7 +307,8 @@ export default function DatasetTable() {
                             setShowInfo(true);
                         },
                     },
-                ]}
+                ]
+                }
                 localization={{
                     header: {
                         actions: "", //remove action buttons' header

--- a/react/src/Datasets/components/DatasetTable.tsx
+++ b/react/src/Datasets/components/DatasetTable.tsx
@@ -307,8 +307,7 @@ export default function DatasetTable({ isAdmin }: DatasetTableProps) {
                             setShowInfo(true);
                         },
                     },
-                ]
-                }
+                ]}
                 localization={{
                     header: {
                         actions: "", //remove action buttons' header

--- a/react/src/Datasets/index.tsx
+++ b/react/src/Datasets/index.tsx
@@ -21,7 +21,11 @@ const useStyles = makeStyles(theme => ({
     },
 }));
 
-export default function Datasets() {
+interface DatasetsProps {
+    isAdmin: boolean;
+}
+
+export default function Datasets({ isAdmin }: DatasetsProps) {
     const classes = useStyles();
 
     useEffect(() => {
@@ -34,7 +38,7 @@ export default function Datasets() {
             <Container maxWidth={false} className={classes.container}>
                 <Grid container spacing={0}>
                     <Grid item xs={12}>
-                        <DatasetTable />
+                        <DatasetTable isAdmin={isAdmin} />
                     </Grid>
                 </Grid>
             </Container>

--- a/react/src/Login.tsx
+++ b/react/src/Login.tsx
@@ -52,7 +52,7 @@ export default function LoginForm({
             const data = await result.json();
             setGlobalUsername(data["username"]);
             setLastLoginTime(data["last_login"]);
-            setIsAdmin(data["is_admin"])
+            setIsAdmin(data["is_admin"]);
             setError("");
         } else {
             setError(await result.text());

--- a/react/src/Login.tsx
+++ b/react/src/Login.tsx
@@ -32,6 +32,7 @@ export default function LoginForm({
     setAuthenticated = (auth: boolean) => {},
     setLastLoginTime = (lastLogin: string) => {},
     setGlobalUsername = (username: string) => {},
+    setIsAdmin = (isAdmin: boolean) => {},
 }) {
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
@@ -51,6 +52,7 @@ export default function LoginForm({
             const data = await result.json();
             setGlobalUsername(data["username"]);
             setLastLoginTime(data["last_login"]);
+            setIsAdmin(data["is_admin"])
             setError("");
         } else {
             setError(await result.text());

--- a/react/src/Navigation.tsx
+++ b/react/src/Navigation.tsx
@@ -178,6 +178,7 @@ export interface NavigationProps {
     lastLoginTime: string;
     darkMode: boolean;
     toggleDarkMode: () => void;
+    isAdmin: boolean;
 }
 
 export default function Navigation({
@@ -186,6 +187,7 @@ export default function Navigation({
     lastLoginTime,
     darkMode,
     toggleDarkMode,
+    isAdmin,
 }: NavigationProps) {
     const classes = useStyles(darkMode)();
     const [open, setOpen] = useState(localStorage.getItem("drawerOpen") === "true");
@@ -265,12 +267,13 @@ export default function Navigation({
                     <Divider />
                     <List>
                         {routes.map((route, index) => (
-                            <ListItemRouterLink
+                            route.path !== "/admin" || isAdmin ? <ListItemRouterLink
                                 key={index}
                                 to={route.linkTo ? route.linkTo : "" + route.path}
                                 primary={route.pageName}
                                 children={route.icon}
                             />
+                                : <></>
                         ))}
                     </List>
                     <Divider />

--- a/react/src/Navigation.tsx
+++ b/react/src/Navigation.tsx
@@ -277,7 +277,7 @@ export default function Navigation({
                                     children={route.icon}
                                 />
                             ) : (
-                                <></>
+                                <React.Fragment key={index} />
                             )
                         )}
                     </List>
@@ -312,7 +312,7 @@ export default function Navigation({
                                 }}
                             />
                         ) : (
-                            <Redirect to={`/participants`} />
+                            <Redirect key={index} to={`/participants`} />
                         )
                     )}
                 </Switch>

--- a/react/src/Navigation.tsx
+++ b/react/src/Navigation.tsx
@@ -300,6 +300,8 @@ export default function Navigation({
                                 switch (route.path) {
                                     case "/settings":
                                         return <route.main username={username} />;
+                                    case "/datasets/:id?":
+                                            return <route.main isAdmin={isAdmin} />;
                                     default:
                                         return <route.main />;
                                 }

--- a/react/src/Navigation.tsx
+++ b/react/src/Navigation.tsx
@@ -268,15 +268,18 @@ export default function Navigation({
                     </div>
                     <Divider />
                     <List>
-                        {routes.map((route, index) => (
-                            !route.requiresAdmin || isAdmin ? <ListItemRouterLink
-                                key={index}
-                                to={route.linkTo ? route.linkTo : "" + route.path}
-                                primary={route.pageName}
-                                children={route.icon}
-                            />
-                                : <></>
-                        ))}
+                        {routes.map((route, index) =>
+                            !route.requiresAdmin || isAdmin ? (
+                                <ListItemRouterLink
+                                    key={index}
+                                    to={route.linkTo ? route.linkTo : "" + route.path}
+                                    primary={route.pageName}
+                                    children={route.icon}
+                                />
+                            ) : (
+                                <></>
+                            )
+                        )}
                     </List>
                     <Divider />
                     <div className={classes.bottomItems}>
@@ -291,26 +294,27 @@ export default function Navigation({
                     </div>
                 </Drawer>
                 <Switch>
-                    {routes.map((route, index) => (
-                        !route.requiresAdmin || isAdmin ? <Route
-                            key={index}
-                            path={route.path}
-                            exact={route.exact}
-                            render={() => {
-                                switch (route.path) {
-                                    case "/settings":
-                                        return <route.main username={username} />;
-                                    case "/datasets/:id?":
-                                        return <route.main isAdmin={isAdmin} />;
-                                    default:
-                                        return <route.main />;
-                                }
-                            }}
-                        />
-                            : <Redirect
-                                to={`/participants`}
+                    {routes.map((route, index) =>
+                        !route.requiresAdmin || isAdmin ? (
+                            <Route
+                                key={index}
+                                path={route.path}
+                                exact={route.exact}
+                                render={() => {
+                                    switch (route.path) {
+                                        case "/settings":
+                                            return <route.main username={username} />;
+                                        case "/datasets/:id?":
+                                            return <route.main isAdmin={isAdmin} />;
+                                        default:
+                                            return <route.main />;
+                                    }
+                                }}
                             />
-                    ))}
+                        ) : (
+                            <Redirect to={`/participants`} />
+                        )
+                    )}
                 </Switch>
             </BrowserRouter>
         </div>

--- a/react/src/Navigation.tsx
+++ b/react/src/Navigation.tsx
@@ -301,7 +301,7 @@ export default function Navigation({
                                     case "/settings":
                                         return <route.main username={username} />;
                                     case "/datasets/:id?":
-                                            return <route.main isAdmin={isAdmin} />;
+                                        return <route.main isAdmin={isAdmin} />;
                                     default:
                                         return <route.main />;
                                 }

--- a/react/src/Navigation.tsx
+++ b/react/src/Navigation.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from "react";
 import clsx from "clsx";
-import { BrowserRouter, Switch, Route, RouteProps } from "react-router-dom";
+import { BrowserRouter, Switch, Route, RouteProps, Redirect } from "react-router-dom";
 import {
     makeStyles,
     CssBaseline,
@@ -120,6 +120,7 @@ interface RouteItem extends RouteProps {
     linkTo?: string; // Used as path for links
     main: (props: any) => JSX.Element; // The page itself
     icon?: React.ReactElement; // Icon for menu links
+    requiresAdmin?: boolean; // If the route requires admin
 }
 
 /**
@@ -169,6 +170,7 @@ const routes: RouteItem[] = [
         path: "/admin",
         main: Admin,
         icon: <VerifiedUserIcon />,
+        requiresAdmin: true,
     },
 ];
 
@@ -267,7 +269,7 @@ export default function Navigation({
                     <Divider />
                     <List>
                         {routes.map((route, index) => (
-                            route.path !== "/admin" || isAdmin ? <ListItemRouterLink
+                            !route.requiresAdmin || isAdmin ? <ListItemRouterLink
                                 key={index}
                                 to={route.linkTo ? route.linkTo : "" + route.path}
                                 primary={route.pageName}
@@ -290,7 +292,7 @@ export default function Navigation({
                 </Drawer>
                 <Switch>
                     {routes.map((route, index) => (
-                        <Route
+                        !route.requiresAdmin || isAdmin ? <Route
                             key={index}
                             path={route.path}
                             exact={route.exact}
@@ -303,6 +305,9 @@ export default function Navigation({
                                 }
                             }}
                         />
+                            : <Redirect
+                                to={`/participants`}
+                            />
                     ))}
                 </Switch>
             </BrowserRouter>


### PR DESCRIPTION
Closes #216 
No admin page option if you're not logged in as an admin. Trying to access /admin route and other invalid routes redirects to /participants. The dataset delete button is hidden if not admin.

You can change the default admin's permissions by doing the following to the default database: 
```
docker exec -it st2020_mysql_1 /bin/bash
mysql -u $MYSQL_USER -p $MYSQL_DATABASE
# Enter MYSQL_PASSWORD
insert into users_groups values (1,1); insert into groups_datasets values (1,1);
# Toggle permissions
update user set is_admin=(not is_admin) where user_id=1;
```
Then refresh frontend

Take a good look, I probably missed something