### PR TITLE
Flask: blueprints re-factor, extract helpers and separate extensions

### DIFF
--- a/flask/app/__init__.py
+++ b/flask/app/__init__.py
@@ -25,10 +25,10 @@ def create_app(config):
     app = Flask(__name__)
     app.config.from_object(config)
 
+    config_logger(app)
     register_extensions(app)
     register_commands(app)
     register_blueprints(app)
-    config_logger(app)
 
     return app
 

--- a/flask/app/__init__.py
+++ b/flask/app/__init__.py
@@ -9,6 +9,19 @@ login = LoginManager()
 migrate = Migrate()
 
 
+from app import (
+    buckets,
+    routes,
+    families,
+    datasets,
+    participants,
+    tissue_samples,
+    analyses,
+    groups,
+    users,
+)
+
+
 def create_app(config):
     """
     The application factory. Returns an instance of the app.
@@ -31,17 +44,25 @@ def create_app(config):
     login.init_app(app)
     migrate.init_app(app, db)
 
+    register_blueprints(app)
+
     with app.app_context():
         # Import here so that other modules have access to the app context
         from . import manage
-        from . import routes
-        from . import buckets
-        from . import analyses
-        from . import families
-        from . import datasets
-        from . import participants
-        from . import tissue_samples
-        from . import groups
-        from . import users
 
         return app
+
+
+def register_blueprints(app):
+
+    app.register_blueprint(routes.routes)
+
+    app.register_blueprint(families.family_blueprint)
+    app.register_blueprint(datasets.datasets_blueprint)
+    app.register_blueprint(participants.participants_blueprint)
+    app.register_blueprint(tissue_samples.tissue_blueprint)
+    app.register_blueprint(analyses.analyses_blueprint)
+
+    app.register_blueprint(buckets.bucket_blueprint)
+    app.register_blueprint(groups.groups_blueprint)
+    app.register_blueprint(users.users_blueprint)

--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -5,14 +5,20 @@ from dataclasses import asdict
 
 from . import db, login, models, routes
 
-from flask import abort, jsonify, request, Response, current_app as app
+from flask import abort, jsonify, request, Response, Blueprint, current_app as app
 from flask_login import login_user, logout_user, current_user, login_required
 from sqlalchemy import exc
 from sqlalchemy.orm import contains_eager, aliased, joinedload
 from werkzeug.exceptions import HTTPException
 
 
-@app.route("/api/analyses", methods=["GET"], endpoint="analyses_list")
+analyses_blueprint = Blueprint(
+    "analyses",
+    __name__,
+)
+
+
+@analyses_blueprint.route("/api/analyses", methods=["GET"], endpoint="analyses_list")
 @login_required
 def list_analyses():
     if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
@@ -71,7 +77,7 @@ def list_analyses():
     )
 
 
-@app.route("/api/analyses/<int:id>", methods=["GET"])
+@analyses_blueprint.route("/api/analyses/<int:id>", methods=["GET"])
 @login_required
 def get_analysis(id: int):
     if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
@@ -138,7 +144,7 @@ def get_analysis(id: int):
     )
 
 
-@app.route("/api/analyses", methods=["POST"])
+@analyses_blueprint.route("/api/analyses", methods=["POST"])
 @login_required
 def create_analysis():
     if not request.json:
@@ -208,7 +214,7 @@ def create_analysis():
     )
 
 
-@app.route("/api/analyses/<int:id>", methods=["DELETE"])
+@analyses_blueprint.route("/api/analyses/<int:id>", methods=["DELETE"])
 @login_required
 @routes.check_admin
 def delete_analysis(id: int):
@@ -225,7 +231,7 @@ def delete_analysis(id: int):
         return "Server error", 500
 
 
-@app.route("/api/analyses/<int:id>", methods=["PATCH"])
+@analyses_blueprint.route("/api/analyses/<int:id>", methods=["PATCH"])
 @login_required
 def update_analysis(id: int):
     if not request.json:

--- a/flask/app/analyses.py
+++ b/flask/app/analyses.py
@@ -291,7 +291,7 @@ def update_analysis(id: int):
             else:
                 return "assignee not found", 400
 
-    enum_error = routes.mixin(analysis, request.json, editable_columns)
+    enum_error = utils.mixin(analysis, request.json, editable_columns)
 
     if enum_error:
         return enum_error, 400

--- a/flask/app/buckets.py
+++ b/flask/app/buckets.py
@@ -1,21 +1,29 @@
-from flask import jsonify, current_app as app
+from flask import jsonify, Blueprint, current_app as app
 from flask_login import current_user, login_required
 from minio import Minio
 from sqlalchemy.orm import joinedload
 
 from . import models
 
-minioClient = Minio(
-    app.config.get("MINIO_ENDPOINT"),
-    access_key=app.config.get("MINIO_ACCESS_KEY"),
-    secret_key=app.config.get("MINIO_SECRET_KEY"),
-    secure=False,
+
+bucket_blueprint = Blueprint(
+    "buckets",
+    __name__,
 )
 
 
-@app.route("/api/unlinked", methods=["GET"])
+@bucket_blueprint.route("/api/unlinked", methods=["GET"])
 @login_required
 def get_unlinked_files():
+
+    # temporary solution since Minio can't access the app without context
+    with app.app_context():
+        minioClient = Minio(
+            app.config.get("MINIO_ENDPOINT"),
+            access_key=app.config.get("MINIO_ACCESS_KEY"),
+            secret_key=app.config.get("MINIO_SECRET_KEY"),
+            secure=False,
+        )
 
     # Get all minio bucket names
     all_bucket_names = [bucket.name for bucket in minioClient.list_buckets()]

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -3,7 +3,8 @@ import json
 from typing import Any, Callable, Dict, List, Union
 from dataclasses import asdict
 
-from . import db, login, models
+from .extensions import db, login
+from . import models
 
 from flask import abort, jsonify, request, Response, Blueprint, current_app as app
 from flask_login import login_user, logout_user, current_user, login_required

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -3,13 +3,16 @@ import json
 from typing import Any, Callable, Dict, List, Union
 from dataclasses import asdict
 
-from . import db, login, models, routes
+from . import db, login, models
 
 from flask import abort, jsonify, request, Response, Blueprint, current_app as app
 from flask_login import login_user, logout_user, current_user, login_required
 from sqlalchemy import exc
 from sqlalchemy.orm import aliased, joinedload
 from werkzeug.exceptions import HTTPException
+
+from .utils import mixin, transaction_or_abort, check_admin, enum_validate
+
 
 editable_columns = [
     "dataset_type",
@@ -169,7 +172,7 @@ def update_dataset(id: int):
     else:
         dataset = models.Dataset.query.filter_by(dataset_id=id).first_or_404()
 
-    enum_error = routes.mixin(dataset, request.json, editable_columns)
+    enum_error = mixin(dataset, request.json, editable_columns)
 
     if enum_error:
         return enum_error, 400
@@ -185,7 +188,7 @@ def update_dataset(id: int):
     if user_id:
         dataset.updated_by_id = user_id
 
-    routes.transaction_or_abort(db.session.commit)
+    transaction_or_abort(db.session.commit)
 
     return jsonify(
         {
@@ -198,7 +201,7 @@ def update_dataset(id: int):
 
 @datasets_blueprint.route("/api/datasets/<int:id>", methods=["DELETE"])
 @login_required
-@routes.check_admin
+@check_admin
 def delete_dataset(id: int):
     dataset = (
         models.Dataset.query.filter(models.Dataset.dataset_id == id)
@@ -235,7 +238,7 @@ def create_dataset():
         tissue_sample_id=tissue_sample_id
     ).first_or_404()
 
-    enum_error = routes.enum_validate(models.Dataset, request.json, editable_columns)
+    enum_error = enum_validate(models.Dataset, request.json, editable_columns)
 
     if enum_error:
         return enum_error, 400
@@ -271,7 +274,7 @@ def create_dataset():
         for path in request.json["linked_files"]:
             dataset.files.append(models.DatasetFile(path=path))
     db.session.add(dataset)
-    routes.transaction_or_abort(db.session.commit)
+    transaction_or_abort(db.session.commit)
     ds_id = dataset.dataset_id
     location_header = "/api/datasets/{}".format(ds_id)
 

--- a/flask/app/datasets.py
+++ b/flask/app/datasets.py
@@ -5,7 +5,7 @@ from dataclasses import asdict
 
 from . import db, login, models, routes
 
-from flask import abort, jsonify, request, Response, current_app as app
+from flask import abort, jsonify, request, Response, Blueprint, current_app as app
 from flask_login import login_user, logout_user, current_user, login_required
 from sqlalchemy import exc
 from sqlalchemy.orm import aliased, joinedload
@@ -28,8 +28,13 @@ editable_columns = [
     "discriminator",
 ]
 
+datasets_blueprint = Blueprint(
+    "datasets",
+    __name__,
+)
 
-@app.route("/api/datasets", methods=["GET"])
+
+@datasets_blueprint.route("/api/datasets", methods=["GET"])
 @login_required
 def list_datasets():
     if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
@@ -73,7 +78,7 @@ def list_datasets():
     )
 
 
-@app.route("/api/datasets/<int:id>", methods=["GET"])
+@datasets_blueprint.route("/api/datasets/<int:id>", methods=["GET"])
 @login_required
 def get_dataset(id: int):
     if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
@@ -138,7 +143,7 @@ def get_dataset(id: int):
     )
 
 
-@app.route("/api/datasets/<int:id>", methods=["PATCH"])
+@datasets_blueprint.route("/api/datasets/<int:id>", methods=["PATCH"])
 @login_required
 def update_dataset(id: int):
     if not request.json:
@@ -191,7 +196,7 @@ def update_dataset(id: int):
     )
 
 
-@app.route("/api/datasets/<int:id>", methods=["DELETE"])
+@datasets_blueprint.route("/api/datasets/<int:id>", methods=["DELETE"])
 @login_required
 @routes.check_admin
 def delete_dataset(id: int):
@@ -212,7 +217,7 @@ def delete_dataset(id: int):
         return "Dataset has analyses, cannot delete", 422
 
 
-@app.route("/api/datasets", methods=["POST"])
+@datasets_blueprint.route("/api/datasets", methods=["POST"])
 @login_required
 def create_dataset():
     if not request.json:

--- a/flask/app/extensions.py
+++ b/flask/app/extensions.py
@@ -1,0 +1,14 @@
+"""
+load extensions
+"""
+
+
+from flask_login import LoginManager
+from flask_migrate import Migrate
+from flask_sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+login = LoginManager()
+migrate = Migrate()
+
+login.session_protection = "strong"

--- a/flask/app/extensions.py
+++ b/flask/app/extensions.py
@@ -1,8 +1,3 @@
-"""
-load extensions
-"""
-
-
 from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy

--- a/flask/app/families.py
+++ b/flask/app/families.py
@@ -1,13 +1,18 @@
 from dataclasses import asdict
 
-from flask import abort, jsonify, request, Response, current_app as app
+from flask import abort, jsonify, request, Response, Blueprint, current_app as app
 from flask_login import login_user, logout_user, current_user, login_required
 from app import db, login, models
 from sqlalchemy.orm import contains_eager, joinedload
 from .routes import check_admin, transaction_or_abort
 
+family_blueprint = Blueprint(
+    "families",
+    __name__,
+)
 
-@app.route("/api/families", methods=["GET"])
+
+@family_blueprint.route("/api/families", methods=["GET"])
 @login_required
 def list_families():
     starts_with = request.args.get("starts_with", default="", type=str)
@@ -76,7 +81,7 @@ def list_families():
     )
 
 
-@app.route("/api/families/<int:id>", methods=["GET"])
+@family_blueprint.route("/api/families/<int:id>", methods=["GET"])
 @login_required
 def get_family(id: int):
     if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
@@ -152,7 +157,7 @@ def get_family(id: int):
     )
 
 
-@app.route("/api/families/<int:id>", methods=["DELETE"])
+@family_blueprint.route("/api/families/<int:id>", methods=["DELETE"])
 @login_required
 @check_admin
 def delete_family(id: int):
@@ -174,7 +179,7 @@ def delete_family(id: int):
         return "Family has participants, cannot delete!", 422
 
 
-@app.route("/api/families/<int:id>", methods=["PATCH"])
+@family_blueprint.route("/api/families/<int:id>", methods=["PATCH"])
 @login_required
 def update_family(id: int):
 
@@ -232,7 +237,7 @@ def update_family(id: int):
         return "Server error", 500
 
 
-@app.route("/api/families", methods=["POST"])
+@family_blueprint.route("/api/families", methods=["POST"])
 @login_required
 @check_admin
 def create_family():

--- a/flask/app/families.py
+++ b/flask/app/families.py
@@ -4,7 +4,7 @@ from flask import abort, jsonify, request, Response, Blueprint, current_app as a
 from flask_login import login_user, logout_user, current_user, login_required
 from app import db, login, models
 from sqlalchemy.orm import contains_eager, joinedload
-from .routes import check_admin, transaction_or_abort
+from .utils import check_admin, transaction_or_abort
 
 family_blueprint = Blueprint(
     "families",

--- a/flask/app/families.py
+++ b/flask/app/families.py
@@ -2,7 +2,8 @@ from dataclasses import asdict
 
 from flask import abort, jsonify, request, Response, Blueprint, current_app as app
 from flask_login import login_user, logout_user, current_user, login_required
-from app import db, login, models
+from .extensions import db, login
+from . import models
 from sqlalchemy.orm import contains_eager, joinedload
 from .utils import check_admin, transaction_or_abort
 

--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -1,4 +1,4 @@
-from flask import abort, jsonify, request, Response, current_app as app
+from flask import abort, jsonify, request, Response, Blueprint, current_app as app
 from flask_login import login_user, logout_user, current_user, login_required
 from app import db, login, models
 from sqlalchemy.orm import contains_eager, joinedload
@@ -7,7 +7,13 @@ from minio import Minio
 from .madmin import MinioAdmin, readwrite_buckets_policy
 
 
-@app.route("/api/groups", methods=["GET"])
+groups_blueprint = Blueprint(
+    "groups",
+    __name__,
+)
+
+
+@groups_blueprint.route("/api/groups", methods=["GET"])
 @login_required
 def list_groups():
     if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
@@ -32,7 +38,7 @@ def list_groups():
     )
 
 
-@app.route("/api/groups/<string:group_code>", methods=["GET"])
+@groups_blueprint.route("/api/groups/<string:group_code>", methods=["GET"])
 @login_required
 def get_group(group_code):
     if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
@@ -66,7 +72,7 @@ def get_group(group_code):
     )
 
 
-@app.route("/api/groups/<string:group_code>", methods=["PATCH"])
+@groups_blueprint.route("/api/groups/<string:group_code>", methods=["PATCH"])
 @login_required
 @check_admin
 def update_group(group_code):
@@ -123,7 +129,7 @@ def update_group(group_code):
         return "Server error", 500
 
 
-@app.route("/api/groups", methods=["POST"])
+@groups_blueprint.route("/api/groups", methods=["POST"])
 @login_required
 @check_admin
 def create_group():
@@ -197,7 +203,7 @@ def create_group():
     return request.json, 201, {"location": location_header}
 
 
-@app.route("/api/groups/<string:group_code>", methods=["DELETE"])
+@groups_blueprint.route("/api/groups/<string:group_code>", methods=["DELETE"])
 @login_required
 @check_admin
 def delete_group(group_code):

--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -1,6 +1,7 @@
 from flask import abort, jsonify, request, Response, Blueprint, current_app as app
 from flask_login import login_user, logout_user, current_user, login_required
-from app import db, login, models
+from .extensions import db, login
+from . import models
 from sqlalchemy.orm import contains_eager, joinedload
 from .utils import check_admin, transaction_or_abort, mixin
 

--- a/flask/app/groups.py
+++ b/flask/app/groups.py
@@ -2,7 +2,8 @@ from flask import abort, jsonify, request, Response, Blueprint, current_app as a
 from flask_login import login_user, logout_user, current_user, login_required
 from app import db, login, models
 from sqlalchemy.orm import contains_eager, joinedload
-from .routes import check_admin, transaction_or_abort, mixin
+from .utils import check_admin, transaction_or_abort, mixin
+
 from minio import Minio
 from .madmin import MinioAdmin, readwrite_buckets_policy
 

--- a/flask/app/manage.py
+++ b/flask/app/manage.py
@@ -1,9 +1,15 @@
-from flask import current_app as app
-from . import db, models
 from datetime import datetime
 
+from flask import current_app as app
+import click
+from flask.cli import with_appcontext
 
-@app.cli.command("add-default-admin")
+from .extensions import db
+from . import models
+
+
+@click.command("add-default-admin")
+@with_appcontext
 def add_default_admin():
     if len(db.session.query(models.User).all()) == 0:
         default_admin = models.User(
@@ -23,7 +29,8 @@ def add_default_admin():
         )
 
 
-@app.cli.command("add-dummy-data")
+@click.command("add-dummy-data")
+@with_appcontext
 def add_dummy_data():
     # add groups
     if len(db.session.query(models.Group).all()) == 0:

--- a/flask/app/participants.py
+++ b/flask/app/participants.py
@@ -3,7 +3,8 @@ import json
 from typing import Any, Callable, Dict, List, Union
 from dataclasses import asdict
 
-from . import db, login, models
+from .extensions import db, login
+from . import models
 
 from flask import abort, jsonify, request, Response, Blueprint, current_app as app
 from flask_login import login_user, logout_user, current_user, login_required

--- a/flask/app/participants.py
+++ b/flask/app/participants.py
@@ -5,7 +5,7 @@ from dataclasses import asdict
 
 from . import db, login, models, routes
 
-from flask import abort, jsonify, request, Response, current_app as app
+from flask import abort, jsonify, request, Response, Blueprint, current_app as app
 from flask_login import login_user, logout_user, current_user, login_required
 from sqlalchemy import exc
 from sqlalchemy.orm import aliased, contains_eager, joinedload
@@ -23,7 +23,13 @@ editable_columns = [
 ]
 
 
-@app.route("/api/participants", methods=["GET"])
+participants_blueprint = Blueprint(
+    "participants",
+    __name__,
+)
+
+
+@participants_blueprint.route("/api/participants", methods=["GET"])
 @login_required
 def list_participants():
 
@@ -107,7 +113,7 @@ def list_participants():
     )
 
 
-@app.route("/api/participants/<int:id>", methods=["DELETE"])
+@participants_blueprint.route("/api/participants/<int:id>", methods=["DELETE"])
 @login_required
 @routes.check_admin
 def delete_participant(id: int):
@@ -128,7 +134,7 @@ def delete_participant(id: int):
         return "Participant has tissue samples, cannot delete", 422
 
 
-@app.route("/api/participants/<int:id>", methods=["PATCH"])
+@participants_blueprint.route("/api/participants/<int:id>", methods=["PATCH"])
 @login_required
 def update_participant(id: int):
 
@@ -184,7 +190,7 @@ def update_participant(id: int):
     )
 
 
-@app.route("/api/participants", methods=["POST"])
+@participants_blueprint.route("/api/participants", methods=["POST"])
 @login_required
 @routes.check_admin
 def create_participant():

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -10,7 +10,8 @@ from flask_login import current_user, login_required, login_user, logout_user
 from sqlalchemy.orm import aliased, contains_eager, joinedload
 from werkzeug.exceptions import HTTPException
 
-from . import db, login, models
+from .extensions import db, login
+from . import models
 
 from .utils import check_admin, transaction_or_abort, enum_validate
 

--- a/flask/app/routes.py
+++ b/flask/app/routes.py
@@ -2,32 +2,19 @@ import inspect
 from dataclasses import asdict
 from datetime import datetime
 from enum import Enum
-from functools import wraps
 from io import StringIO
-from typing import Any, Callable, Dict, List, Union
 
 import pandas as pd
-from flask import abort, current_app as app, jsonify, Response, request
+from flask import current_app as app, jsonify, Response, request, Blueprint
 from flask_login import current_user, login_required, login_user, logout_user
-from sqlalchemy import exc
 from sqlalchemy.orm import aliased, contains_eager, joinedload
 from werkzeug.exceptions import HTTPException
 
 from . import db, login, models
 
+from .utils import check_admin, transaction_or_abort, enum_validate
 
-def mixin(
-    entity: db.Model, json_mixin: Dict[str, Any], columns: List[str]
-) -> Union[None, str]:
-    for field in columns:
-        if field in json_mixin:
-            column = getattr(entity, field)
-            value = json_mixin[field]
-            if isinstance(column, Enum):
-                if not hasattr(type(column), str(value)):
-                    allowed = [e.value for e in type(column)]
-                    return f'"{field}" must be one of {allowed}'
-            setattr(entity, field, value)
+routes = Blueprint("routes", __name__)
 
 
 @login.user_loader
@@ -35,7 +22,7 @@ def load_user(uid: int):
     return models.User.query.get(uid)
 
 
-@app.route("/api/login", methods=["POST"])
+@routes.route("/api/login", methods=["POST"])
 def login():
     last_login = None
     if current_user.is_authenticated:
@@ -71,7 +58,7 @@ def login():
     return jsonify({"username": user.username, "last_login": last_login})
 
 
-@app.route("/api/logout", methods=["POST"])
+@routes.route("/api/logout", methods=["POST"])
 @login_required
 def logout():
     if not request.json:
@@ -80,31 +67,7 @@ def logout():
     return "", 204
 
 
-def check_admin(handler):
-    @wraps(handler)
-    def decorated_handler(*args, **kwargs):
-        if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
-            return handler(*args, **kwargs)
-        return "Unauthorized", 401
-
-    return decorated_handler
-
-
-def transaction_or_abort(callback: Callable) -> None:
-    try:
-        callback()
-    except exc.DataError as err:
-        db.session.rollback()
-        abort(400, description=err.orig.args[1])
-    except exc.StatementError as err:
-        db.session.rollback()
-        abort(400, description=str(err.orig))
-    except Exception as err:
-        db.session.rollback()
-        raise err
-
-
-@app.errorhandler(HTTPException)
+@routes.errorhandler(HTTPException)
 def on_http_exception(error: HTTPException) -> Response:
     response = error.get_response()
     response.content_type = "text/plain"
@@ -123,7 +86,7 @@ def validate_user(request_user: dict):
     return False
 
 
-@app.route("/api/users", methods=["PUT"])
+@routes.route("/api/users", methods=["PUT"])
 @login_required
 @check_admin
 def update_user():
@@ -145,7 +108,7 @@ def update_user():
         return "Server error", 500
 
 
-@app.route("/api/users", methods=["DELETE"])
+@routes.route("/api/users", methods=["DELETE"])
 @login_required
 @check_admin
 def delete_user():
@@ -163,7 +126,7 @@ def delete_user():
         return "Server error", 500
 
 
-@app.route("/api/password", methods=["POST"])
+@routes.route("/api/password", methods=["POST"])
 @login_required
 def change_password():
     params = request.get_json()
@@ -185,7 +148,7 @@ def change_password():
         return "Server error", 500
 
 
-@app.route("/api/pipelines", methods=["GET"], endpoint="pipelines_list")
+@routes.route("/api/pipelines", methods=["GET"], endpoint="pipelines_list")
 @login_required
 def pipelines_list():
     db_pipelines = (
@@ -197,7 +160,7 @@ def pipelines_list():
     return jsonify(db_pipelines)
 
 
-@app.route("/api/enums", methods=["GET"])
+@routes.route("/api/enums", methods=["GET"])
 @login_required
 def get_enums():
     enums = {}
@@ -218,21 +181,7 @@ def get_enums():
     return jsonify(enums)
 
 
-def enum_validate(
-    entity: db.Model, json_mixin: Dict[str, any], columns: List[str]
-) -> Union[None, str]:
-
-    for field in columns:
-        if field in json_mixin:
-            column = getattr(entity, field)  # the column type from the entities
-            value = json_mixin[field]
-            if hasattr(column.type, "enums"):  # check if enum
-                if value not in column.type.enums and value is not None:
-                    allowed = column.type.enums
-                    return f'Invalid value for: "{field}", current input is "{value}" but must be one of {allowed}'
-
-
-@app.route("/api/_bulk", methods=["POST"])
+@routes.route("/api/_bulk", methods=["POST"])
 @login_required
 def bulk_update():
 

--- a/flask/app/tissue_samples.py
+++ b/flask/app/tissue_samples.py
@@ -1,10 +1,16 @@
 from dataclasses import asdict
 
-from flask import abort, jsonify, request, Response, current_app as app
+from flask import abort, jsonify, request, Response, Blueprint, current_app as app
 from flask_login import login_user, logout_user, current_user, login_required
 from app import db, login, models
 from sqlalchemy.orm import contains_eager, joinedload
 from .routes import check_admin, transaction_or_abort, mixin, enum_validate
+
+
+tissue_blueprint = Blueprint(
+    "tissue",
+    __name__,
+)
 
 
 editable_columns = [
@@ -15,7 +21,7 @@ editable_columns = [
 ]
 
 
-@app.route("/api/tissue_samples/<int:id>", methods=["GET"])
+@tissue_blueprint.route("/api/tissue_samples/<int:id>", methods=["GET"])
 @login_required
 def get_tissue_sample(id: int):
     if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
@@ -74,7 +80,7 @@ def get_tissue_sample(id: int):
     )
 
 
-@app.route("/api/tissue_samples/<int:id>", methods=["DELETE"])
+@tissue_blueprint.route("/api/tissue_samples/<int:id>", methods=["DELETE"])
 @login_required
 @check_admin
 def delete_tissue_sample(id: int):
@@ -97,7 +103,7 @@ def delete_tissue_sample(id: int):
         return "Tissue has dataset(s), cannot delete", 422
 
 
-@app.route("/api/tissue_samples", methods=["POST"])
+@tissue_blueprint.route("/api/tissue_samples", methods=["POST"])
 @login_required
 @check_admin
 def create_tissue_sample():
@@ -156,7 +162,7 @@ def create_tissue_sample():
         return "Server error", 500
 
 
-@app.route("/api/tissue_samples/<int:id>", methods=["PATCH"])
+@tissue_blueprint.route("/api/tissue_samples/<int:id>", methods=["PATCH"])
 @login_required
 def update_tissue_sample(id: int):
     if not request.json:

--- a/flask/app/tissue_samples.py
+++ b/flask/app/tissue_samples.py
@@ -4,7 +4,7 @@ from flask import abort, jsonify, request, Response, Blueprint, current_app as a
 from flask_login import login_user, logout_user, current_user, login_required
 from app import db, login, models
 from sqlalchemy.orm import contains_eager, joinedload
-from .routes import check_admin, transaction_or_abort, mixin, enum_validate
+from .utils import check_admin, transaction_or_abort, mixin, enum_validate
 
 
 tissue_blueprint = Blueprint(

--- a/flask/app/tissue_samples.py
+++ b/flask/app/tissue_samples.py
@@ -2,7 +2,8 @@ from dataclasses import asdict
 
 from flask import abort, jsonify, request, Response, Blueprint, current_app as app
 from flask_login import login_user, logout_user, current_user, login_required
-from app import db, login, models
+from .extensions import db, login
+from . import models
 from sqlalchemy.orm import contains_eager, joinedload
 from .utils import check_admin, transaction_or_abort, mixin, enum_validate
 

--- a/flask/app/users.py
+++ b/flask/app/users.py
@@ -4,15 +4,20 @@ from typing import Any, Dict
 from flask_login import current_user, login_required
 from sqlalchemy.orm import joinedload
 
-from flask import current_app as app
+from flask import Blueprint, current_app as app, current_app as app
 from flask import jsonify, request
 
 from . import db, models
 from .madmin import MinioAdmin
 from .routes import check_admin, transaction_or_abort
 
+users_blueprint = Blueprint(
+    "users",
+    __name__,
+)
 
-@app.route("/api/users", methods=["GET"])
+
+@users_blueprint.route("/api/users", methods=["GET"])
 @login_required
 @check_admin
 def list_users():
@@ -47,7 +52,7 @@ def jsonify_user(user: models.User):
     )
 
 
-@app.route("/api/users/<string:username>", methods=["GET"])
+@users_blueprint.route("/api/users/<string:username>", methods=["GET"])
 @login_required
 def get_user(username: str):
     if (
@@ -92,7 +97,7 @@ def reset_minio_credentials(user: models.User) -> None:
     user.minio_secret_key = secret_key
 
 
-@app.route("/api/users/<string:username>", methods=["POST"])
+@users_blueprint.route("/api/users/<string:username>", methods=["POST"])
 @login_required
 def reset_minio_user(username: str):
     if (
@@ -139,7 +144,7 @@ def verify_email(email: str) -> bool:
     return space == -1 and at > 0 and dot > at + 1
 
 
-@app.route("/api/users", methods=["POST"])
+@users_blueprint.route("/api/users", methods=["POST"])
 @login_required
 @check_admin
 def create_user():

--- a/flask/app/users.py
+++ b/flask/app/users.py
@@ -7,7 +7,9 @@ from sqlalchemy.orm import joinedload
 from flask import Blueprint, current_app as app, current_app as app
 from flask import jsonify, request
 
-from . import db, models
+from .extensions import db
+from . import models
+
 from .madmin import MinioAdmin
 from .utils import check_admin, transaction_or_abort
 

--- a/flask/app/users.py
+++ b/flask/app/users.py
@@ -9,7 +9,7 @@ from flask import jsonify, request
 
 from . import db, models
 from .madmin import MinioAdmin
-from .routes import check_admin, transaction_or_abort
+from .utils import check_admin, transaction_or_abort
 
 users_blueprint = Blueprint(
     "users",

--- a/flask/app/utils.py
+++ b/flask/app/utils.py
@@ -8,7 +8,7 @@ from sqlalchemy import exc
 
 
 from flask import current_app as app
-from app import db  # from extensions
+from .extensions import db
 
 
 def mixin(

--- a/flask/app/utils.py
+++ b/flask/app/utils.py
@@ -1,0 +1,64 @@
+from functools import wraps
+from enum import Enum
+from typing import Any, Callable, Dict, List, Union
+
+from flask import abort
+from flask_login import current_user
+from sqlalchemy import exc
+
+
+from flask import current_app as app
+from app import db  # from extensions
+
+
+def mixin(
+    entity: db.Model, json_mixin: Dict[str, Any], columns: List[str]
+) -> Union[None, str]:
+    for field in columns:
+        if field in json_mixin:
+            column = getattr(entity, field)
+            value = json_mixin[field]
+            if isinstance(column, Enum):
+                if not hasattr(type(column), str(value)):
+                    allowed = [e.value for e in type(column)]
+                    return f'"{field}" must be one of {allowed}'
+            setattr(entity, field, value)
+
+
+def check_admin(handler):
+    @wraps(handler)
+    def decorated_handler(*args, **kwargs):
+        with app.app_context():
+            if app.config.get("LOGIN_DISABLED") or current_user.is_admin:
+                return handler(*args, **kwargs)
+        return "Unauthorized", 401
+
+    return decorated_handler
+
+
+def transaction_or_abort(callback: Callable) -> None:
+    try:
+        callback()
+    except exc.DataError as err:
+        db.session.rollback()
+        abort(400, description=err.orig.args[1])
+    except exc.StatementError as err:
+        db.session.rollback()
+        abort(400, description=str(err.orig))
+    except Exception as err:
+        db.session.rollback()
+        raise err
+
+
+def enum_validate(
+    entity: db.Model, json_mixin: Dict[str, any], columns: List[str]
+) -> Union[None, str]:
+
+    for field in columns:
+        if field in json_mixin:
+            column = getattr(entity, field)  # the column type from the entities
+            value = json_mixin[field]
+            if hasattr(column.type, "enums"):  # check if enum
+                if value not in column.type.enums and value is not None:
+                    allowed = column.type.enums
+                    return f'Invalid value for: "{field}", current input is "{value}" but must be one of {allowed}'


### PR DESCRIPTION
closes #221

- separating extensions from `__init__.py` into `extensions.py`
- as part of removing circular imports (imports from .extensions as opposed to import from app), logging and cli commands are also registered to the flask application through `__init__.py`
- blueprint refactor and registering
- extract shared helpers into `utils.py`