### PR TITLE
Flask: initialize MinIO policies for groups in dummy data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
+# Production image. Runs a Guicorn WSGI server.
 FROM minio/mc:latest AS mc
 FROM python:3.7-slim
 WORKDIR /var/www/sample-tracker/flask
+# Install PyPI prod-only packages first and then copy the MinIO client as the latter updates more frequently
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 COPY --from=mc /usr/bin/mc /usr/bin/mc
 COPY . .
 EXPOSE 5000
-ENTRYPOINT ["./utils/wait-for-it.sh", "mysql:3306", "--timeout=0", "--", "./utils/run.sh"]
-CMD ["prod", "--bind", "0.0.0.0:5000", "--preload", "--workers", "1", "--threads", "2"]
+# Prevent accidentally using this image for development by adding the prod server arguments in the entrypoint
+ENTRYPOINT ["./utils/wait-for-it.sh", "mysql:3306", "--timeout=0", "--", "./utils/run.sh", "prod", "--bind", "0.0.0.0:5000"]
+CMD ["--preload", "--workers", "1", "--threads", "2"]

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -25,6 +25,7 @@ services:
       context: flask
       dockerfile: ../Dockerfile
     image: ccmbio/st2020:edge
+    restart: on-failure
     environment:
       FLASK_ENV: production
       ST_DATABASE_URI: "mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql/${MYSQL_DATABASE}"
@@ -36,6 +37,7 @@ services:
       - minio
   nginx:
     image: nginx:alpine
+    restart: on-failure
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,6 @@ services:
   app:
     build: flask
     image: ccmbio/st2020
-    restart: on-failure
     environment:
       FLASK_ENV: development
       ST_DATABASE_URI: "mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql/${MYSQL_DATABASE}"

--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -1,10 +1,15 @@
+# Development image only. Runs a Flask development server.
 FROM minio/mc:latest AS mc
 FROM python:3.7-slim
 WORKDIR /var/www/sample-tracker/flask
+# Install PyPI packages first and then copy the MinIO client as the latter updates more frequently
 COPY requirements-dev.txt .
 RUN pip3 install -r requirements-dev.txt
 COPY --from=mc /usr/bin/mc /usr/bin/mc
-COPY . .
+# Prevent accidentally running this image in production.
+# Must mount the source code in the working directory to run this image.
+# COPY . .
 EXPOSE 5000
 ENTRYPOINT ["./utils/wait-for-it.sh", "mysql:3306", "--timeout=0", "--", "./utils/run.sh"]
+# Allows us to replace the parameters to run tests or formatters instead of the app.
 CMD ["--host=0.0.0.0"]

--- a/react/.gitignore
+++ b/react/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.eslintcache


### PR DESCRIPTION
Other:
- ignore .eslintcache
- Docker: prevent accidentally running prod images in dev and vice versa
- Compose: restart prod containers on failure, not dev